### PR TITLE
Send to Address via self-send

### DIFF
--- a/src/components/dialogs/SendAddressDialog.vue
+++ b/src/components/dialogs/SendAddressDialog.vue
@@ -83,8 +83,7 @@ export default {
         const txHex = transaction.toString()
 
         try {
-          const electrumHandler = this.$electrumClient
-          await electrumHandler.request('blockchain.transaction.broadcast', txHex)
+          await this.$relayClient.emptySelfSend(transaction)
           sentTransactionNotify()
           console.log('Sent transaction', txHex)
         } catch (err) {


### PR DESCRIPTION
**Motivation**
Currently, when sending a typical p2pkh from a stamp wallet the event is not recorded in the inbox.

**Solution**
We attach the transaction to an empty self send.

It may be better to encode the wallet transaction and record it in an entry rather than doing it this way. This should be discussed and acted on. A modification to this code can be used in the future.