### PR TITLE
Make sure message retries don't print duplicates

### DIFF
--- a/src/adapters/vuex-relay-adapter.js
+++ b/src/adapters/vuex-relay-adapter.js
@@ -18,14 +18,14 @@ export async function getRelayClient ({ wallet, electrumClient, store, relayUrl 
     console.log(err)
   })
   client.events.on('opened', () => { observables.connected = true })
-  client.events.on('messageSending', ({ address, senderAddress, index, items, outpoints, transactions }) => {
-    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions })
+  client.events.on('messageSending', ({ address, senderAddress, index, items, outpoints, transactions, previousHash }) => {
+    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, previousHash })
   })
-  client.events.on('messageSendError', ({ address, senderAddress, index, items, outpoints, transactions, retryData }) => {
-    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, retryData, status: 'error' })
+  client.events.on('messageSendError', ({ address, senderAddress, index, items, outpoints, transactions, previousHash }) => {
+    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, previousHash, status: 'error' })
   })
-  client.events.on('messageSent', ({ address, senderAddress, index, items, outpoints, transactions }) => {
-    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, status: 'confirmed' })
+  client.events.on('messageSent', ({ address, senderAddress, index, items, outpoints, transactions, previousHash }) => {
+    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, previousHash, status: 'confirmed' })
   })
   client.events.on('receivedMessage', (args) => {
     store.dispatch('chats/receiveMessage', args)

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -228,7 +228,7 @@ export default {
       }
       state.activeChatAddr = address
     },
-    sendMessageLocal (state, { address, senderAddress, index, items, outpoints = [], status = 'pending', retryData = null }) {
+    sendMessageLocal (state, { address, senderAddress, index, items, outpoints = [], status = 'pending', previousHash = null }) {
       const apiAddress = toAPIAddress(address)
 
       const timestamp = Date.now()
@@ -239,8 +239,8 @@ export default {
         serverTime: timestamp,
         receivedTime: timestamp,
         outpoints,
-        retryData,
-        senderAddress
+        senderAddress,
+        messageHash: index
       }
       assert(newMsg.outbound !== undefined, 'outbound is not defined')
       assert(newMsg.status !== undefined, 'status is not defined')
@@ -254,6 +254,20 @@ export default {
       if (index in state.messages) {
         // we have the message already, just need to update some fields and return
         state.messages[index] = Object.assign(state.messages[index], message)
+        return
+      }
+
+      if (index in state.messages) {
+        // we have the message already, just need to update some fields and return
+        state.messages[index] = Object.assign(state.messages[index], message)
+        return
+      }
+
+      if (previousHash in state.messages) {
+        // we have the message already, just need to update some fields and return
+        const msgIndex = state.chats[apiAddress].messages.findIndex((msg) => msg.messageHash === previousHash)
+        state.chats[apiAddress].messages.splice(msgIndex, 1)
+        delete state.messages[index]
         return
       }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,11 +4,11 @@ import { ElectrumTransport } from 'electrum-cash'
 // Electrum constants
 export const electrumServers = [
   // Our mainnet server, we need to setup a testnet server as well.
-  // {
-  //   url: 'fulcrum.cashweb.io',
-  //   port: 443,
-  //   scheme: ElectrumTransport.WSS.Scheme
-  // }
+  {
+    url: 'fulcrum.cashweb.io',
+    port: 443,
+    scheme: ElectrumTransport.WSS.Scheme
+  }
   // {
   //   url: 'electrum.bitcoinabc.org',
   //   port: 50004,
@@ -24,38 +24,40 @@ export const electrumServers = [
   //   port: 60006,
   //   scheme: ElectrumTransport.WS.Scheme
   // },
-  {
-    url: 'tfulcrum.cashweb.io',
-    port: 443,
-    scheme: ElectrumTransport.WSS.Scheme
-  }
+  // {
+  //   url: 'tfulcrum.cashweb.io',
+  //   port: 443,
+  //   scheme: ElectrumTransport.WSS.Scheme
+  // }
 ]
 
 // The separation here is due the fork. Not all backends support the new network prefixes yet
 // So we are using the legacy prefixes everywhere for API calls, but using
 // the ecash prefix for display
-export const networkName = 'testnet'
-export const displayNetwork = 'ecash-testnet'
+// export const networkName = 'testnet'
+// export const displayNetwork = 'ecash-testnet'
+export const networkName = 'mainnet'
+export const displayNetwork = 'ecash-mainnet'
 
 export const electrumPingInterval = 10_000
 
 // Wallet constants
 export const numAddresses = 10
 export const numChangeAddresses = 10
-export const recomendedBalance = 500_000
+export const recomendedBalance = 5_000_000
 export const nUtxoGoal = 10
 export const feeUpdateTimerMilliseconds = 60_000
 export const defaultFeePerByte = 2
 
 // Keyserver constants
-export const trustedKeyservers = ['https://keyserver.cashweb.io']
+export const trustedKeyservers = ['https://mainnet-keyserver.cashweb.io']
 
 // Relay constants
 export const pingTimeout = 20_000
 export const relayReconnectInterval = 10_000
 export const defaultAcceptancePrice = 100
-export const defaultRelayUrl = 'https://relay.cashweb.io'
-export const relayUrlOptions = ['https://relay.cashweb.io']
+export const defaultRelayUrl = 'https://mainnet-relay.cashweb.io'
+export const relayUrlOptions = ['https://mainnet-relay.cashweb.io']
 export const defaultRelayData = {
   profile: {
     name: '',
@@ -86,16 +88,7 @@ export const defaultAvatars = ['bunny_cyborg.png', 'croc_music.png', 'kitty_stan
 
 // Chat constants
 export const defaultStampAmount = 5000
-export const defaultContacts = [
-  {
-    name: 'Harry',
-    address: 'bchtest:qq3q7kzdds2xuzug05tn7w3lp7kkfulqfsf85x8tty'
-  },
-  {
-    name: 'Shammah',
-    address: 'bchtest:qqu3vqt9hydcmhkydn9h68qzlyduypuwqgnc8vvjhc'
-  }
-]
+export const defaultContacts = []
 
 // Notification constants
 export const notificationTimeout = 4000


### PR DESCRIPTION
Currently, we retry 3 times by default to send a message. This was to
handle network desynchronizations. This isn't as necessary as it use
to be, but it still happens from time to time. This commit fixes
the appearance of three messages when there is a network error.
