### PR TITLE
Make sure message retries don't print duplicates

### DIFF
--- a/src/adapters/vuex-relay-adapter.js
+++ b/src/adapters/vuex-relay-adapter.js
@@ -18,14 +18,14 @@ export async function getRelayClient ({ wallet, electrumClient, store, relayUrl 
     console.log(err)
   })
   client.events.on('opened', () => { observables.connected = true })
-  client.events.on('messageSending', ({ address, senderAddress, index, items, outpoints, transactions }) => {
-    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions })
+  client.events.on('messageSending', ({ address, senderAddress, index, items, outpoints, transactions, previousHash }) => {
+    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, previousHash })
   })
-  client.events.on('messageSendError', ({ address, senderAddress, index, items, outpoints, transactions, retryData }) => {
-    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, retryData, status: 'error' })
+  client.events.on('messageSendError', ({ address, senderAddress, index, items, outpoints, transactions, previousHash }) => {
+    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, previousHash, status: 'error' })
   })
-  client.events.on('messageSent', ({ address, senderAddress, index, items, outpoints, transactions }) => {
-    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, status: 'confirmed' })
+  client.events.on('messageSent', ({ address, senderAddress, index, items, outpoints, transactions, previousHash }) => {
+    store.commit('chats/sendMessageLocal', { address, senderAddress, index, items, outpoints, transactions, previousHash, status: 'confirmed' })
   })
   client.events.on('receivedMessage', (args) => {
     store.dispatch('chats/receiveMessage', args)

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -228,7 +228,7 @@ export default {
       }
       state.activeChatAddr = address
     },
-    sendMessageLocal (state, { address, senderAddress, index, items, outpoints = [], status = 'pending', retryData = null }) {
+    sendMessageLocal (state, { address, senderAddress, index, items, outpoints = [], status = 'pending', previousHash = null }) {
       const apiAddress = toAPIAddress(address)
 
       const timestamp = Date.now()
@@ -239,8 +239,8 @@ export default {
         serverTime: timestamp,
         receivedTime: timestamp,
         outpoints,
-        retryData,
-        senderAddress
+        senderAddress,
+        messageHash: index
       }
       assert(newMsg.outbound !== undefined, 'outbound is not defined')
       assert(newMsg.status !== undefined, 'status is not defined')
@@ -254,6 +254,14 @@ export default {
       if (index in state.messages) {
         // we have the message already, just need to update some fields and return
         state.messages[index] = Object.assign(state.messages[index], message)
+        return
+      }
+
+      if (previousHash in state.messages) {
+        // we have the message already, just need to update some fields and return
+        const msgIndex = state.chats[apiAddress].messages.findIndex((msg) => msg.messageHash === previousHash)
+        state.chats[apiAddress].messages.splice(msgIndex, 1)
+        delete state.messages[index]
         return
       }
 


### PR DESCRIPTION
Currently, we retry 3 times by default to send a message. This was to
handle network desynchronizations. This isn't as necessary as it use
to be, but it still happens from time to time. This commit fixes
the appearance of three messages when there is a network error.
