### PR TITLE
Make account setup step more intuitive

### DIFF
--- a/src/components/setup/AccountStep.vue
+++ b/src/components/setup/AccountStep.vue
@@ -1,44 +1,67 @@
 <template>
   <div class="col q-gutter-y-md">
-    <q-input
-      v-model="name"
-      filled
-      :label="$t('profile.name')"
-      lazy-rules
-      style="width:100%"
-      :rules="[ val => !!val || val.length > 0 || $t('profile.pleaseType') ]"
-    />
-    <q-input
-      v-model="seed"
-      ref="seedInput"
-      :label="$t('profile.seedEntry')"
-      type="textarea"
-      filled
-      rows="2"
-      lazy-rules
-      :rules=" [ val => isSeedValid || $t('profile.invalidSeed') ]"
-      :placeholder="$t('profile.enterSeed')"
-    />
-    <q-btn
-      flat
-      class="q-pa-xs q-ma-none"
-      color="primary"
-      icon="content_copy"
-      @click="copySeed"
-    />
-    <q-btn
-      flat
-      class="q-pa-xs q-ma-none"
-      color="primary"
-      icon="refresh"
-      @click="generateMnemonic"
-    />
-    <q-btn
-      class="q-ma-xs q-ma-xs"
-      color="primary"
-      :label="$t('profile.importSeed')"
-      @click="pasteImported"
-    />
+    <div v-if="action === 'none'">
+      <div class="row q-ma-xs q-ma-xs">
+        <q-space />
+        <q-btn
+          class="q-ma-xs q-ma-xsrow"
+          color="primary"
+          label="New Character"
+          @click="newCharacter"
+        />
+        <q-space />
+      </div>
+      <div class="row q-ma-xs q-ma-xs">
+        <q-space />
+        <q-btn
+          class="row q-ma-xs q-ma-xs "
+          color="primary"
+          label="Import Character"
+          @click="importCharacter"
+        />
+        <q-space />
+      </div>
+    </div>
+
+    <div v-if="action !== 'none'">
+      <q-input
+        v-if="action === 'new'"
+        v-model="name"
+        filled
+        :label="$t('profile.name')"
+        lazy-rules
+        style="width:100%"
+        :rules="[ val => !!val || val.length > 0 || $t('profile.pleaseType') ]"
+      />
+      <q-input
+        :readonly="action === 'new'"
+        v-model="seed"
+        ref="seedInput"
+        :label="$t('profile.seedEntry')"
+        type="textarea"
+        filled
+        rows="2"
+        lazy-rules
+        :rules=" [ val => isSeedValid || $t('profile.invalidSeed') ]"
+        :placeholder="$t('profile.enterSeed')"
+      />
+      <q-btn
+        v-if="action === 'new'"
+        flat
+        class="q-pa-xs q-ma-none"
+        color="primary"
+        icon="content_copy"
+        @click="copySeed"
+      />
+      <q-btn
+        v-if="action === 'new'"
+        flat
+        class="q-pa-xs q-ma-none"
+        color="primary"
+        icon="refresh"
+        @click="generateMnemonic"
+      />
+    </div>
   </div>
 </template>
 
@@ -60,7 +83,7 @@ export default {
   },
   data () {
     return {
-      importSeed: false
+      action: 'none'
     }
   },
   methods: {
@@ -81,6 +104,15 @@ export default {
       this.seed = ''
       document.body.removeChild(el)
       this.$nextTick(() => this.$refs.seedInput.select())
+    },
+    newCharacter () {
+      this.generateMnemonic()
+      this.action = 'new'
+      this.name = ''
+    },
+    importCharacter () {
+      this.action = 'import'
+      this.seed = ''
     }
   },
   computed: {
@@ -97,7 +129,13 @@ export default {
       }
     },
     isValid () {
-      return this.isSeedValid && (this.accountData.name.length > 1)
+      if (this.action === 'new') {
+        return this.accountData.name.length > 0 && this.isSeedValid
+      }
+      if (this.action === 'import') {
+        return this.isSeedValid
+      }
+      return false
     },
     isSeedValid () {
       return validateMnemonic(this.seed.toLowerCase().trim())


### PR DESCRIPTION
Instead of trying to give people one (confusing) flow for setting up
a machine, give them a choice. This will enable the content to be more
directed at new users vs existing users.
