### PR TITLE
Implement a quick-and-dirty way to reset your remote wallet

### DIFF
--- a/src/components/panels/SettingsPanel.vue
+++ b/src/components/panels/SettingsPanel.vue
@@ -94,15 +94,29 @@
 
           <q-item-section>{{ $t('SettingPanel.settings') }}</q-item-section>
         </q-item>
+        <q-separator />
+
+        <q-item
+          clickable
+          v-ripple
+          @click="deleteForever"
+        >
+          <q-item-section avatar>
+            <q-icon name="delete_forever" />
+          </q-item-section>
+
+          <q-item-section>{{ $t('SettingPanel.wipeAndSave') }}</q-item-section>
+        </q-item>
       </q-list>
     </q-scroll-area>
   </div>
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import ContactCard from './ContactCard.vue'
 import ContactBookDialog from '../dialogs/ContactBookDialog.vue'
+import { errorNotify } from '../../utils/notifications'
 
 const settingsRoutes = [
   '/settings',
@@ -142,6 +156,9 @@ export default {
     event: 'update:drawerOpen'
   },
   methods: {
+    ...mapMutations({
+      deleteMessage: 'chats/deleteMessage'
+    }),
     ...mapActions({
       setActiveChat: 'chats/setActiveChat'
     }),
@@ -165,6 +182,18 @@ export default {
     },
     newContact () {
       openPage(this.$router, this.$route.path, '/add-contact')
+    },
+    deleteForever () {
+      this.$q.loading.show({
+        delay: 100,
+        message: this.$t('SettingPanel.wipeAndSave')
+      })
+      this.$relayClient.wipeWallet(({ address, payloadDigest, index }) => {
+        this.deleteMessage({ address, payloadDigest, index })
+      }).then(() => this.$q.loading.hide()).catch((err) => {
+        errorNotify(err)
+        this.$q.loading.hide()
+      })
     }
   },
   computed: {

--- a/src/i18n/en-us/index.ts
+++ b/src/i18n/en-us/index.ts
@@ -52,7 +52,8 @@ export default {
     sendBitcoinCash: 'Send eCash',
     recieveBitcoinCash: 'Receive eCash',
     profile: 'Profile',
-    settings: 'Settings'
+    settings: 'Settings',
+    wipeAndSave: 'Remote Wipe Wallet'
   },
   receiveBitcoinDialog: {
     walletStatus: 'Wallet Status',

--- a/src/relay/client.js
+++ b/src/relay/client.js
@@ -748,6 +748,19 @@ export class RelayClient {
     const metadata = constructProfileMetadata(profile, priceFilter, idPrivKey)
     await this.putProfile(idPrivKey.toAddress(networkName).toCashAddress().toString(), metadata)
   }
+
+  async wipeWallet (messageDeleter) {
+    const messageIterator = await this.messageStore.getIterator()
+    // Todo, this rehydrate stuff is common to receiveMessage
+    for await (const messageWrapper of messageIterator) {
+      if (!messageWrapper.newMsg) {
+        continue
+      }
+      const { index, copartyAddress } = messageWrapper
+      await this.deleteMessage(messageWrapper.index)
+      messageDeleter({ address: copartyAddress, payloadDigest: index, index })
+    }
+  }
 }
 
 export default RelayClient


### PR DESCRIPTION
This needs some UX work, and some optimizations for combining outputs.
However, for the time being, we don't want to accidentally fail to
broadcast a transaction, and then delete the remote message.

Additionally, we probably need some confirmation and warning dialogs.
