### PR TITLE
Update doc to able to remote debugging ios device with Safari inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ quasar build -m capacitor -T android
 ```bash
 quasar build -m capacitor -T ios
 ```
+In order to remote debugging on real ios device, the devtools option in quasar.conf.js should not be 'source-map'. Instead try 'eval-source-map'
+The root cause is that the Safari web inspector disconnects/crashes when the size of any files are too large.
 
 ### Updating the generated protobuf files:
 


### PR DESCRIPTION
Issue: The safari inspector keeps crashing when remote debugging with real iOS device.
Root cause: The inspector crashes when any file is too large (not sure the limit)
Reference: https://stackoverflow.com/questions/31251938/safari-web-inspector-keeps-disconnecting
Solution: Should change the "devtools" option in quasar.conf.js file from 'source-map' to others, such as 'eval-source-map'