### PR TITLE
Fix spelling of 'unknown' in bitcore typedef

### DIFF
--- a/src/types/bitcore-lib-xpi/bitcore-lib-xpi.d.ts
+++ b/src/types/bitcore-lib-xpi/bitcore-lib-xpi.d.ts
@@ -272,8 +272,8 @@ declare module 'bitcore-lib-xpi' {
 
         isStandard (): boolean;
 
-        prepend (obj: unkown): this;
-        add (obj: unkown): this;
+        prepend (obj: unknown): this;
+        add (obj: unknown): this;
 
         hasCodeseparators (): boolean;
         removeCodeseparators (): this;


### PR DESCRIPTION
This should presumably have blown up; but did not. Fixing it.
