### PR TITLE
Fix refresh of messages after posting

### DIFF
--- a/src/store/modules/agora.ts
+++ b/src/store/modules/agora.ts
@@ -59,7 +59,7 @@ const module: Module<State, unknown> = {
       const keyserver = new KeyserverHandler({ wallet, networkName: displayNetwork, keyservers })
       console.log('fetching messages')
       await keyserver.createBroadcast(topic, [entry], satoshis)
-      await dispatch('refreshMessages', { wallet, topic: getters.getSelectedTopic() })
+      await dispatch('refreshMessages', { wallet, topic: getters.getSelectedTopic })
     }
   }
 }


### PR DESCRIPTION
Due to the fact that vuex isn't particularly typescript aware, the agora
store was incorrectly attempting to call a non-function. This commit
removes the function call syntax causing the error.