### PR TITLE
Add basic vote support

### DIFF
--- a/src/store/modules/agora.ts
+++ b/src/store/modules/agora.ts
@@ -109,6 +109,12 @@ const module: Module<State, unknown> = {
       commit('setMessage', message)
       // Need to refetch so we get the right proxy object
       return getters.getMessage(payloadDigest)
+    },
+    async addOffering ({ dispatch, getters }, { wallet, payloadDigest, satoshis }: { wallet: Wallet, payloadDigest: string, satoshis: number }) {
+      const keyserver = new KeyserverHandler({ wallet, networkName: displayNetwork, keyservers })
+      console.log('voting towards message', payloadDigest, satoshis)
+      await keyserver.addOfferings(payloadDigest, satoshis)
+      await dispatch('refreshMessages', { wallet, topic: getters.getSelectedTopic })
     }
   }
 }


### PR DESCRIPTION
This commit adds voting support to the Agora. The UX is currently adding
10 XPI per vote or downvote, and they are delayed so that only one
transaction is sent per set of clicks provided they all happen within 1
second of the first click.
