### PR TITLE
Ensure message entries without a payload are ignored

### DIFF
--- a/src/cashweb/keyserver/handler.ts
+++ b/src/cashweb/keyserver/handler.ts
@@ -315,7 +315,10 @@ export class KeyserverHandler {
     for (const entry of entries) {
       const kind = entry.getKind()
       const payload = entry.getPayload()
-      assert(typeof payload !== 'string', `invalid payload type returned from protobufs ${payload}`)
+      if (typeof payload === 'string') {
+        console.error('invalid payload type returned from protobufs')
+        continue
+      }
 
       if (kind === 'post') {
         const post = AgoraPost.deserializeBinary(payload)


### PR DESCRIPTION
Currently, if a payload is absent from an entry, protobufs returns an
empty string. This trips an assertion that was added to make typescript
happy and prevents the Agora page from loading if such a message exists.

Somehow someone posted such a blank message to the server. Possibly due
to an unknown bug, or someone is playing with the source.
