### PR TITLE
Fix blowing up when posts reference parent posts which are unknown

### DIFF
--- a/src/components/agora/AgoraMessage.vue
+++ b/src/components/agora/AgoraMessage.vue
@@ -121,9 +121,9 @@
           :messages="message.replies"
           v-if="showReplies"
         />
-        <q-separator v-if="showParent && parentDigest" />
+        <q-separator v-if="showParent && parentDigest && parentMessage" />
         <q-card-section
-          v-if="showParent && parentDigest"
+          v-if="showParent && parentDigest && parentMessage"
           class="q-pa-none"
         >
           <q-card-section class="q-pa-sm">
@@ -155,8 +155,8 @@ import { AgoraMessage } from '../../cashweb/types/agora'
 export default defineComponent({
   props: {
     message: {
-      default: undefined,
-      type: Object as PropType<AgoraMessage | undefined>
+      default: () => ({ poster: undefined, satoshis: 0, replies: [], entries: [], payloadDigest: undefined, topic: '' }),
+      type: Object as PropType<AgoraMessage>
     },
     showParent: {
       default: false,


### PR DESCRIPTION
This is a temporary fix for this problem. Ideally, the client would
attempt to download the parent where relevant. It is hard to follow a
conversation if this doesn't happen.
