### PR TITLE
Allow deeplinking to specific Agora posts for unregistered users

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,7 @@ import { Store } from 'vuex'
 import { createRoutes } from './routes'
 import { RootState } from 'src/store/modules'
 
-const unprotectedRoutes = ['/', '/agora', '/setup', '/changelog']
+const unprotectedRoutes = ['/', '/setup', '/agora', '/changelog']
 
 async function addContactFromNavigation<S> (store: Store<S>, address: string) {
   try {
@@ -39,7 +39,7 @@ export default ({ store }: { store: Store<RootState> }) => {
       addContactFromNavigation(store, to.params.address as string)
     }
     console.log('Navigating to', to.fullPath, to.params.address, profile.name)
-    if (profile.name || unprotectedRoutes.includes(to.fullPath)) {
+    if (profile.name || unprotectedRoutes.some(path => to.fullPath.startsWith(path))) {
       next()
     } else {
       console.log('nav to setup!')


### PR DESCRIPTION
Unregistered users could not navigate into replies, or be linked to
specific messages. This commit allows the any subpath of an allow route
past the signup route guard.