### PR TITLE
Fix validation of URLs on CreatePost

### DIFF
--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -29,7 +29,7 @@
           label="URL"
           v-model="url"
           :rules="[
-            val => (val.length >= 0 && validateUrl(val)) || 'Invalid URL'
+            val => !val || validateUrl(val) || 'Invalid URL'
           ]"
           lazy-rules
         />


### PR DESCRIPTION
The validation of posts incorrectly assumes that the URL will always
have a length. However, by default this field is set to null. This
commit simply shortcuts validation when that is the situation.
