### PR TITLE
Refactor the Agora to use router views to dedupe layout

### DIFF
--- a/src/components/agora/AgoraMessage.vue
+++ b/src/components/agora/AgoraMessage.vue
@@ -133,6 +133,7 @@
             In reply to:
           </q-card-section>
           <agora-message
+            v-bind="$attrs"
             class="q-ma-none"
             :message="parentMessage"
             :show-replies="false"

--- a/src/components/agora/AgoraMessageReplies.vue
+++ b/src/components/agora/AgoraMessageReplies.vue
@@ -3,7 +3,10 @@
     v-for="(message) in messages"
     :key="message.payloadDigest"
   >
-    <a-message :message="message" />
+    <a-message
+      v-bind="$attrs"
+      :message="message"
+    />
   </template>
 </template>
 

--- a/src/layouts/AgoraLayout.vue
+++ b/src/layouts/AgoraLayout.vue
@@ -1,0 +1,105 @@
+<template>
+  <q-layout
+    view="lhh LpR lff"
+    container
+    class="hide-scrollbar absolute full-width"
+  >
+    <q-header>
+      <q-toolbar class="q-pl-sm">
+        <q-btn
+          class="q-px-sm"
+          flat
+          dense
+          @click="toggleSettingsDrawerOpen"
+          icon="menu"
+        />
+        <q-toolbar-title class="h6">
+          Agora
+        </q-toolbar-title>
+        <q-space />
+        <q-btn
+          icon="refresh"
+          flat
+          @click="refreshContent"
+        />
+        <q-input
+          filled
+          class="q-mx-sm q-pa-none"
+          v-model="selectedTopic"
+          label="Topic"
+          style="width: 250px"
+          @keyup.enter.prevent="refreshContent"
+          clearable
+        />
+        <q-btn
+          flat
+          class="q-mx-sm q-pa-sm"
+          label="Create Post"
+          to="/create-post"
+        />
+      </q-toolbar>
+    </q-header>
+
+    <q-page-container>
+      <q-page>
+        <q-scroll-area
+          ref="chatScroll"
+          class="q-px-sm absolute full-width full-height"
+        >
+          <router-view @set-topic="setTopic" />
+        </q-scroll-area>
+      </q-page>
+    </q-page-container>
+  </q-layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { mapGetters, mapActions, mapMutations } from 'vuex'
+
+export default defineComponent({
+  data () {
+    return { }
+  },
+  emits: ['toggleMyDrawerOpen'],
+  mounted () {
+    this.refreshContent()
+  },
+  methods: {
+    ...mapActions({
+      refreshMessages: 'agora/refreshMessages'
+    }),
+    ...mapMutations({
+      setSelectedTopic: 'agora/setSelectedTopic'
+    }),
+    toggleSettingsDrawerOpen () {
+      this.$emit('toggleMyDrawerOpen')
+    },
+    refreshContent () {
+      this.refreshMessages({ wallet: this.$wallet, topic: this.selectedTopic })
+    },
+    setTopic (text: string) {
+      this.selectedTopic = text
+      this.refreshContent()
+    }
+  },
+  computed: {
+    ...mapGetters({
+      topics: 'agora/getTopics',
+      getSelectedTopic: 'agora/getSelectedTopic'
+    }),
+    selectedTopic: {
+      set (newVal?: string) {
+        this.setSelectedTopic(newVal ?? '')
+        // If the contents were cleared then we should refresh.
+        if (!newVal) {
+          this.refreshContent()
+        }
+      },
+      get (): string {
+        return this.getSelectedTopic
+      }
+    }
+  }
+})
+</script>

--- a/src/pages/Agora.vue
+++ b/src/pages/Agora.vue
@@ -1,66 +1,15 @@
 <template>
-  <q-layout
-    view="lhh LpR lff"
-    container
-    class="hide-scrollbar absolute full-width"
+  <template
+    v-for="(message) in messages"
+    :key="message.payloadDigest"
   >
-    <q-header>
-      <q-toolbar class="q-pl-sm">
-        <q-btn
-          class="q-px-sm"
-          flat
-          dense
-          @click="toggleSettingsDrawerOpen"
-          icon="menu"
-        />
-        <q-toolbar-title class="h6">
-          Agora
-        </q-toolbar-title>
-        <q-space />
-        <q-btn
-          icon="refresh"
-          flat
-          @click="refreshContent"
-        />
-        <q-input
-          filled
-          class="q-mx-sm q-pa-none"
-          v-model="selectedTopic"
-          label="Topic"
-          style="width: 250px"
-          @keyup.enter.prevent="refreshContent"
-          clearable
-        />
-        <q-btn
-          flat
-          class="q-mx-sm q-pa-sm"
-          label="Create Post"
-          to="/create-post"
-        />
-      </q-toolbar>
-    </q-header>
-
-    <q-page-container>
-      <q-page>
-        <q-scroll-area
-          ref="chatScroll"
-          class="q-px-sm absolute full-width full-height"
-        >
-          <template
-            v-for="(message) in messages"
-            :key="message.payloadDigest"
-          >
-            <a-message
-              :message="message"
-              @set-topic="setTopic"
-              :show-parent="true"
-              :show-replies="false"
-            />
-          </template>
-        </q-scroll-area>
-      </q-page>
-    </q-page-container>
-  </q-layout>
+    <a-message
+      v-bind="$attrs"
+      :message="message"
+      :show-parent="true"
+      :show-replies="false"
+    />
+  </template>
 </template>
 
 <script lang="ts">
@@ -69,16 +18,13 @@ import DOMPurify from 'dompurify'
 
 import { AgoraMessage } from '../cashweb/types/agora'
 import { defineComponent } from 'vue'
-import { mapGetters, mapActions, mapMutations } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 import AMessage from '../components/agora/AgoraMessage.vue'
 
 export default defineComponent({
   props: {},
   components: {
     AMessage
-  },
-  mounted () {
-    this.refreshContent()
   },
   data () {
     return { }
@@ -88,25 +34,15 @@ export default defineComponent({
     ...mapActions({
       refreshMessages: 'agora/refreshMessages'
     }),
-    ...mapMutations({
-      setSelectedTopic: 'agora/setSelectedTopic'
-    }),
     toggleSettingsDrawerOpen () {
       this.$emit('toggleMyDrawerOpen')
     },
     formatSatoshis (value: number) {
       return (value / 1_000_000).toFixed(2)
     },
-    refreshContent () {
-      this.refreshMessages({ wallet: this.$wallet, topic: this.selectedTopic })
-    },
     markedMessage (text: string) {
       const html = DOMPurify.sanitize(marked(text))
       return html
-    },
-    setTopic (text: string) {
-      this.selectedTopic = text
-      this.refreshContent()
     },
     formatAddress (address:string) {
       return address.substring(6, 12) + '...' + address.substring(address.length - 6, address.length)
@@ -118,25 +54,12 @@ export default defineComponent({
   computed: {
     ...mapGetters({
       getMessages: 'agora/getMessages',
-      topics: 'agora/getTopics',
-      getSelectedTopic: 'agora/getSelectedTopic'
+      topics: 'agora/getTopics'
     }),
     messages () {
       return this.getMessages.filter((message: AgoraMessage) =>
         message.entries.some((entry) => entry.kind === 'post')
       )
-    },
-    selectedTopic: {
-      set (newVal?: string) {
-        this.setSelectedTopic(newVal ?? '')
-        // If the contents were cleared then we should refresh.
-        if (!newVal) {
-          this.refreshContent()
-        }
-      },
-      get (): string {
-        return this.getSelectedTopic
-      }
     }
   }
 })

--- a/src/pages/AgoraPost.vue
+++ b/src/pages/AgoraPost.vue
@@ -1,6 +1,7 @@
 <template>
   <q-card class="q-ma-sm">
     <a-message
+      v-bind="$attrs"
       :message="message"
       v-if="message && message.payloadDigest"
       :show-replies="true"

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -4,11 +4,17 @@ export function createRoutes (): RouteRecordRaw[] {
   const routes: RouteRecordRaw[] = [
     {
       path: '/',
+      redirect: '/agora',
       component: () => import('layouts/MainLayout.vue'),
       children: [
-        { path: '', component: () => import('pages/Agora.vue') },
-        { path: 'agora', component: () => import('pages/Agora.vue') },
-        { path: 'agora/:payloadDigest', component: () => import('pages/AgoraPost.vue') },
+        {
+          path: 'agora',
+          component: () => import('layouts/AgoraLayout.vue'),
+          children: [
+            { path: '', component: () => import('pages/Agora.vue') },
+            { path: ':payloadDigest', component: () => import('pages/AgoraPost.vue') }
+          ]
+        },
         { path: 'create-post', component: () => import('pages/CreatePost.vue') },
         { path: 'create-post/:parentDigest', component: () => import('pages/CreatePost.vue') },
         { path: 'changelog', component: () => import('pages/Changelog.vue') },


### PR DESCRIPTION
Currently, the Post Page and the main agora page do not share layouts.
This commit refactors the content to share a layout and use a nested
router-view in order to ensure both pages are rendered in the same way.
Additionally, we add v-bind="$attrs" in order to allow events on message
to propagate all the way back up to the router-view and layout.
