### PR TITLE
Move create post route under Agora subpath

### DIFF
--- a/src/components/agora/AgoraMessage.vue
+++ b/src/components/agora/AgoraMessage.vue
@@ -115,7 +115,7 @@
               padding="1"
               icon="reply"
               label="Reply"
-              :to="`/create-post/${message.payloadDigest}`"
+              :to="`/new-post/${message.payloadDigest}`"
             />
           </q-card-section>
         </q-card-section>

--- a/src/layouts/AgoraLayout.vue
+++ b/src/layouts/AgoraLayout.vue
@@ -35,7 +35,7 @@
           flat
           class="q-mx-sm q-pa-sm"
           label="Create Post"
-          to="/create-post"
+          to="/new-post"
         />
       </q-toolbar>
     </q-header>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -12,11 +12,11 @@ export function createRoutes (): RouteRecordRaw[] {
           component: () => import('layouts/AgoraLayout.vue'),
           children: [
             { path: '', component: () => import('pages/Agora.vue') },
-            { path: ':payloadDigest', component: () => import('pages/AgoraPost.vue') }
+            { path: ':payloadDigest', component: () => import('pages/AgoraPost.vue') },
+            { path: '/new-post', component: () => import('pages/CreatePost.vue') },
+            { path: '/new-post/:parentDigest', component: () => import('pages/CreatePost.vue') }
           ]
         },
-        { path: 'create-post', component: () => import('pages/CreatePost.vue') },
-        { path: 'create-post/:parentDigest', component: () => import('pages/CreatePost.vue') },
         { path: 'changelog', component: () => import('pages/Changelog.vue') },
         { path: 'chat/:address', component: () => import('pages/Chat.vue') },
         { path: 'settings', component: () => import('pages/Settings.vue') },


### PR DESCRIPTION
Moving the create post page under the Agora subpath. This enables it to
use the same layout as the rest of the agora for consistency.
