### PR TITLE
Fix message filtering in Agora main page

### DIFF
--- a/src/pages/Agora.vue
+++ b/src/pages/Agora.vue
@@ -4,6 +4,7 @@
     :key="message.payloadDigest"
   >
     <a-message
+      v-show="showMessage(message.topic)"
       v-bind="$attrs"
       :message="message"
       :show-parent="true"
@@ -27,10 +28,16 @@ export default defineComponent({
     return { }
   },
   emits: [],
+  methods: {
+    showMessage (topic: string) {
+      return topic.startsWith(this.selectedTopic)
+    }
+  },
   computed: {
     ...mapGetters({
       getMessages: 'agora/getMessages',
-      topics: 'agora/getTopics'
+      topics: 'agora/getTopics',
+      selectedTopic: 'agora/getSelectedTopic'
     }),
     messages () {
       return this.getMessages.filter((message: AgoraMessage) =>

--- a/src/store/modules/agora.ts
+++ b/src/store/modules/agora.ts
@@ -87,22 +87,22 @@ const module: Module<State, unknown> = {
     }
   },
   actions: {
-    async refreshMessages ({ commit, getters }, { topic, wallet }: { topic: string, wallet: Wallet }) {
+    async refreshMessages ({ commit, getters }, { wallet }: { topic: string, wallet: Wallet }) {
       const keyserver = new KeyserverHandler({ wallet, networkName: displayNetwork, keyservers })
       console.log('fetching messages')
       const from = (getters.lastMessageTime as (undefined | Date))?.valueOf()
       console.log('from', from)
-      const entries = await keyserver.getBroadcastMessages(topic, from)
+      const entries = await keyserver.getBroadcastMessages('', from)
       if (!entries) {
         return
       }
       commit('setEntries', entries)
     },
-    async putMessage ({ dispatch, getters }, { wallet, entry, satoshis, topic, parentDigest }: { wallet: Wallet, entry: AgoraMessageEntry, satoshis: number, topic: string, parentDigest?: string }) {
+    async putMessage ({ dispatch }, { wallet, entry, satoshis, topic, parentDigest }: { wallet: Wallet, entry: AgoraMessageEntry, satoshis: number, topic: string, parentDigest?: string }) {
       const keyserver = new KeyserverHandler({ wallet, networkName: displayNetwork, keyservers })
       console.log('fetching messages')
       await keyserver.createBroadcast(topic, [entry], satoshis, parentDigest)
-      await dispatch('refreshMessages', { wallet, topic: getters.getSelectedTopic })
+      await dispatch('refreshMessages', { wallet })
     },
     async fetchMessage ({ commit, getters }, { wallet, payloadDigest }: { wallet: Wallet, payloadDigest: string }) {
       const keyserver = new KeyserverHandler({ wallet, networkName: displayNetwork, keyservers })
@@ -116,11 +116,11 @@ const module: Module<State, unknown> = {
       // Need to refetch so we get the right proxy object
       return getters.getMessage(payloadDigest)
     },
-    async addOffering ({ dispatch, getters }, { wallet, payloadDigest, satoshis }: { wallet: Wallet, payloadDigest: string, satoshis: number }) {
+    async addOffering ({ dispatch }, { wallet, payloadDigest, satoshis }: { wallet: Wallet, payloadDigest: string, satoshis: number }) {
       const keyserver = new KeyserverHandler({ wallet, networkName: displayNetwork, keyservers })
       console.log('voting towards message', payloadDigest, satoshis)
       await keyserver.addOfferings(payloadDigest, satoshis)
-      await dispatch('refreshMessages', { wallet, topic: getters.getSelectedTopic })
+      await dispatch('refreshMessages', { wallet })
     }
   }
 }


### PR DESCRIPTION
A previous commit changed the behavior of the Agora fetching routine to
only fetch recent messages. However, this resulted in filtering behavior
not to function correctly as it was processing on the server side. This
commit moves the filtering to the client side and uses v-show instead of
filtering server side so that messages can remain cached locally.
