### PR TITLE
Once again fix message store not to duplicate replies

### DIFF
--- a/src/store/modules/agora.ts
+++ b/src/store/modules/agora.ts
@@ -54,7 +54,7 @@ const module: Module<State, unknown> = {
       state.messages.sort((a, b) => b.satoshis - a.satoshis).map(m => ({ ...m }))
       state.index = indexBy(message => message.payloadDigest, state.messages)
       state.topics = uniq(messages.map(message => message.topic))
-      for (const message of state.messages) {
+      for (const message of newMessages) {
         if (!message.parentDigest) {
           continue
         }


### PR DESCRIPTION
While changing the message download to only fetch new messages, we
inadvertantly got rid of the code to blow out existing replies before
they were reindexed. This code should be optimized to only process new
messages.