### PR TITLE
Fix message load times in forum

### DIFF
--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -179,12 +179,6 @@ export default defineComponent({
   components: {
     AMessageReplies
   },
-  mounted () {
-    if (!this.parentDigest) {
-      return
-    }
-    this.fetchMessage({ wallet: this.$wallet, payloadDigest: this.parentDigest })
-  },
   data () {
     return {
       timeoutId: undefined as (ReturnType<typeof setTimeout> | undefined),
@@ -194,7 +188,6 @@ export default defineComponent({
   emits: ['setTopic'],
   methods: {
     ...mapActions({
-      fetchMessage: 'forum/fetchMessage',
       addOffering: 'forum/addOffering'
     }),
     formatSatoshis (value: number) {


### PR DESCRIPTION
Due to processing messages while they are part of the state the DOM was
attempting to update at the same time. This caused lots of DOM mutations
and redraws which slows down the loadtimes for forum pages
significantly. This commit mutates the lists outside of the DOM updates,
and then sets the whole message state at once.
