### PR TITLE
Fix message updates on votes/posts

### DIFF
--- a/src/cashweb/keyserver/handler.ts
+++ b/src/cashweb/keyserver/handler.ts
@@ -251,6 +251,7 @@ export class KeyserverHandler {
       data: authWrapper.serializeBinary()
     })
     await Promise.all(usedUtxos.map((id: Outpoint) => this.wallet?.storage.deleteOutpoint(calcId(id))))
+    return payloadDigest.toString('hex')
   }
 
   async addOfferings (payloadDigest: string, vote: number) {


### PR DESCRIPTION
When posting or voting on a message, the message or update to votes are
not currently displaying due to the way that caching messages on reload
was setup. This commit forcibly reloads messages which were voted on or
posted.
