### PR TITLE
Fix p2pkh sends

### DIFF
--- a/src/cashweb/relay/index.ts
+++ b/src/cashweb/relay/index.ts
@@ -487,7 +487,7 @@ export class RelayClient extends ReadOnlyRelayClient {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       console.error(err)
-      const payloadDigestHex = err.payloadDigest.toString('hex')
+      const payloadDigestHex = err.payloadDigest?.toString('hex')
       this.events.emit('messageSendError', { address, senderAddress, index: payloadDigestHex, items, outpoints, transactions })
     }
   }

--- a/src/store/modules/chats.ts
+++ b/src/store/modules/chats.ts
@@ -342,8 +342,12 @@ const module: Module<State, unknown> = {
         return
       }
 
+      // Chat may be null if it is a self send
       const chat = state.chats[apiAddress]
-      assert(chat, 'Missing chat bug received message')
+      if (!chat) {
+        // This was a self send, we don't want to update any particular chats.
+        return
+      }
 
       if (previousHash in state.messages) {
         // we have the message already, just need to update some fields and return


### PR DESCRIPTION
When converting over to typescript, it turns out that p2pkh sends do not
work unless you have yourself added as a contact. This will not be the
case for most people. This commit addresses the issue by
short-circuiting the chat message addition and only adds the message to
the overall index for later cache checks and deletions.
