### PR TITLE
Move header buttons to side panel of Forum

### DIFF
--- a/src/components/panels/ForumDrawer.vue
+++ b/src/components/panels/ForumDrawer.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="column full-height">
+    <q-scroll-area
+      class="col"
+    >
+      <q-list>
+        <q-item>
+          <q-input
+            filled
+            class="q-mx-sm q-pa-none"
+            v-model="selectedTopic"
+            label="Topic"
+            style="width: 250px"
+            @keyup.enter.prevent="refreshContent"
+            clearable
+          />
+        </q-item>
+
+        <q-item>
+          <q-btn
+            flat
+            class="q-mx-sm q-pa-sm"
+            label="Create Post"
+            to="/new-post"
+          />
+        </q-item>
+      </q-list>
+    </q-scroll-area>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
+
+export default defineComponent({
+  components: {
+  },
+  data () {
+    return {
+      contactBookOpen: false
+    }
+  },
+  methods: {
+    ...mapActions({
+      refreshMessages: 'forum/refreshMessages'
+    }),
+    ...mapMutations({
+      setSelectedTopic: 'forum/setSelectedTopic'
+    }),
+    refreshContent () {
+      this.refreshMessages({ wallet: this.$wallet, topic: this.selectedTopic })
+    },
+    setTopic (text: string) {
+      this.selectedTopic = text
+      this.refreshContent()
+    }
+  },
+  computed: {
+    ...mapGetters({
+      topics: 'forum/getTopics',
+      getSelectedTopic: 'forum/getSelectedTopic'
+    }),
+    selectedTopic: {
+      set (newVal?: string) {
+        this.setSelectedTopic(newVal ?? '')
+        // If the contents were cleared then we should refresh.
+        if (!newVal) {
+          this.refreshContent()
+        }
+      },
+      get (): string {
+        return this.getSelectedTopic
+      }
+    }
+  }
+})
+</script>

--- a/src/layouts/ForumLayout.vue
+++ b/src/layouts/ForumLayout.vue
@@ -4,6 +4,14 @@
     container
     class="hide-scrollbar absolute full-width"
   >
+    <q-drawer
+      v-model="showForumDrawer"
+      side="right"
+      :breakpoint="800"
+    >
+      <forum-drawer />
+    </q-drawer>
+
     <q-header>
       <q-toolbar class="q-pl-sm">
         <q-btn
@@ -23,20 +31,10 @@
           flat
           @click="refreshContent"
         />
-        <q-input
-          filled
-          class="q-mx-sm q-pa-none"
-          v-model="selectedTopic"
-          label="Topic"
-          style="width: 250px"
-          @keyup.enter.prevent="refreshContent"
-          clearable
-        />
         <q-btn
+          icon="settings"
           flat
-          class="q-mx-sm q-pa-sm"
-          label="Create Post"
-          to="/new-post"
+          @click="showForumDrawer = !showForumDrawer"
         />
       </q-toolbar>
     </q-header>
@@ -58,10 +56,15 @@
 import { defineComponent } from 'vue'
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 
+import ForumDrawer from '../components/panels/ForumDrawer.vue'
+
 export default defineComponent({
   data () {
-    return { }
+    return {
+      showForumDrawer: false
+    }
   },
+  components: { ForumDrawer },
   emits: ['toggleMyDrawerOpen'],
   mounted () {
     this.refreshContent()

--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -80,6 +80,7 @@ export default defineComponent({
   components: {
     AMessage
   },
+  emits: ['setTopic'],
   props: {},
   data () {
     const parentDigest = this.$route.params.parentDigest as string

--- a/src/pages/Forum.vue
+++ b/src/pages/Forum.vue
@@ -27,7 +27,7 @@ export default defineComponent({
   data () {
     return { }
   },
-  emits: [],
+  emits: ['setTopic'],
   methods: {
     showMessage (topic: string) {
       return topic.startsWith(this.selectedTopic)


### PR DESCRIPTION
By using a right drawer for these items we open up some more room
and the potential to add more configuration to how things are displayed
in the future. Currently, the display here kind of stinks, but we
can re-theme things more in the future in an iterative fashion.
