### PR TITLE
Fix topic filtering button on Forum

### DIFF
--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -63,7 +63,7 @@
             flat
             stretch
             padding="1px"
-            @click.prevent="this.$emit('setTopic', message.topic)"
+            @click.prevent="$emit('set-topic', message.topic)"
             :label="message.topic"
           />
           <div class="text-bold text-center q-ma-sm">
@@ -188,7 +188,7 @@ export default defineComponent({
       voteAmount: 0
     }
   },
-  emits: ['setTopic'],
+  emits: ['set-topic'],
   methods: {
     ...mapActions({
       addOffering: 'forum/addOffering'

--- a/src/pages/Forum.vue
+++ b/src/pages/Forum.vue
@@ -5,7 +5,7 @@
   >
     <a-message
       v-show="showMessage(message.topic)"
-      v-bind="$attrs"
+      @set-topic="(...args) => $emit('set-topic', ...args)"
       :message="message"
       :show-parent="true"
       :show-replies="false"
@@ -27,7 +27,7 @@ export default defineComponent({
   data () {
     return { }
   },
-  emits: ['setTopic'],
+  emits: ['set-topic'],
   methods: {
     showMessage (topic: string) {
       return topic.startsWith(this.selectedTopic)


### PR DESCRIPTION
Apparently, `router-view` does not pass through it's listeners via
`$attrs` like the docs say. However, it does work when manually
re-emitting events. Very odd, but this commit fixes the issue.
