### PR TITLE
Add toast on post, and ensure it loads

### DIFF
--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -101,6 +101,7 @@ import { mapActions, mapGetters } from 'vuex'
 import { toMarkdown } from '../utils/markdown'
 
 import AMessage from '../components/forum/ForumMessage.vue'
+import { infoNotify } from 'src/utils/notifications'
 
 export default defineComponent({
   components: {
@@ -145,6 +146,7 @@ export default defineComponent({
       }
       console.log('posting message', entry)
       await this.postMessage({ wallet: this.$wallet, entry, satoshis: this.offering * 1_000_000, topic: this.topic, parentDigest: this.parentDigest })
+      infoNotify('Post created!')
       this.back()
     },
     back () {

--- a/src/pages/Forum.vue
+++ b/src/pages/Forum.vue
@@ -14,7 +14,6 @@
 </template>
 
 <script lang="ts">
-import { ForumMessage } from '../cashweb/types/forum'
 import { defineComponent } from 'vue'
 import { mapGetters } from 'vuex'
 import AMessage from '../components/forum/ForumMessage.vue'
@@ -35,15 +34,10 @@ export default defineComponent({
   },
   computed: {
     ...mapGetters({
-      getMessages: 'forum/getMessages',
+      messages: 'forum/getMessages',
       topics: 'forum/getTopics',
       selectedTopic: 'forum/getSelectedTopic'
-    }),
-    messages () {
-      return this.getMessages.filter((message: ForumMessage) =>
-        message.entries.some((entry) => entry.kind === 'post')
-      )
-    }
+    })
   }
 })
 </script>


### PR DESCRIPTION
The Forum page was not reloading after a post due to the filter within
the computer property. It caused it not to detect that the computed prop
was dependent on the underlying array length. This adds a toast, and
fixes the reload, so that users don't post multiple times thinking their
post did not go through.
