### PR TITLE
Add error notification to Create Post screen

### DIFF
--- a/src/cashweb/keyserver/handler.ts
+++ b/src/cashweb/keyserver/handler.ts
@@ -244,13 +244,18 @@ export class KeyserverHandler {
     authWrapper.setTransactionsList([burnOutput])
     const server = this.chooseServer()
 
-    const url = `${server}/messages`
-    await axios({
-      method: 'put',
-      url: url,
-      data: authWrapper.serializeBinary()
-    })
-    await Promise.all(usedUtxos.map((id: Outpoint) => this.wallet?.storage.deleteOutpoint(calcId(id))))
+    try {
+      const url = `${server}/messages`
+      await axios({
+        method: 'put',
+        url: url,
+        data: authWrapper.serializeBinary()
+      })
+      await Promise.all(usedUtxos.map((id: Outpoint) => this.wallet?.storage.deleteOutpoint(calcId(id))))
+    } catch (err) {
+      await Promise.all(usedUtxos.map(utxo => this.wallet?.fixOutpoint(utxo)))
+      throw err
+    }
     return payloadDigest.toString('hex')
   }
 

--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -101,7 +101,7 @@ import { mapActions, mapGetters } from 'vuex'
 import { toMarkdown } from '../utils/markdown'
 
 import AMessage from '../components/forum/ForumMessage.vue'
-import { infoNotify } from 'src/utils/notifications'
+import { errorNotify, infoNotify } from 'src/utils/notifications'
 
 export default defineComponent({
   components: {
@@ -145,9 +145,17 @@ export default defineComponent({
         message: this.message
       }
       console.log('posting message', entry)
-      await this.postMessage({ wallet: this.$wallet, entry, satoshis: this.offering * 1_000_000, topic: this.topic, parentDigest: this.parentDigest })
+
+      try {
+        await this.postMessage({ wallet: this.$wallet, entry, satoshis: this.offering * 1_000_000, topic: this.topic, parentDigest: this.parentDigest })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (err: any) {
+        errorNotify(err)
+        return
+      } finally {
+        this.back()
+      }
       infoNotify('Post created!')
-      this.back()
     },
     back () {
       window.history.length > 1 ? this.$router.go(-1) : this.$router.push('/')


### PR DESCRIPTION
If a message fails to send for whatever reason, we need to fix our UTXO
set that was frozen and display the error to the user. Ultimately,
this should be wrapped with user-friendly error messages, but for the
purpose of bug reports, leave them displaying all information.
