### PR TITLE
Remove mentions of minimum acceptance price

### DIFF
--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -16,11 +16,6 @@
             icon="person"
             label="Profile"
           />
-          <q-tab
-            name="inbox"
-            icon="mail"
-            label="Inbox"
-          />
         </q-tabs>
       </template>
       <template #after>
@@ -95,23 +90,6 @@
                       @click="cycleAvatarRight"
                     />
                   </div>
-                </div>
-              </div>
-            </div>
-          </q-tab-panel>
-          <q-tab-panel name="inbox">
-            <div class="row">
-              <div class="col">
-                <div class="row q-pa-md">
-                  <q-input
-                    outlined
-                    v-model="internalAceptancePrice"
-                    :label="$t('profile.minimumStamp')"
-                    :hint="$t('profile.minimumStampHint')"
-                    style="width:100%"
-                    type="number"
-                    :rules="[ val => val && val.length > 0 || $t('profile.minimumStampRule')]"
-                  />
                 </div>
               </div>
             </div>

--- a/src/components/panels/ContactCard.vue
+++ b/src/components/panels/ContactCard.vue
@@ -12,23 +12,6 @@
             <img :src="avatar">
           </q-avatar>
         </q-item-section>
-        <q-item-section>
-          <q-item-label
-            style="text-align: right;"
-            class="text-weight-bold text-white"
-            lines="1"
-          >
-            Minimum Stamp
-          </q-item-label>
-          <q-item-label
-            style="text-align: right;"
-            class="text-white"
-            caption
-            lines="1"
-          >
-            {{ acceptancePrice }}
-          </q-item-label>
-        </q-item-section>
       </q-item>
 
       <q-item>

--- a/src/i18n/en-us/index.ts
+++ b/src/i18n/en-us/index.ts
@@ -43,8 +43,7 @@ export default {
   newContactDialog: {
     newContact: 'New Contact',
     enterBitcoinCashAddress: 'Enter Lotus address...',
-    notFound: 'Not Found',
-    minimumStamp: 'Minimum Stamp'
+    notFound: 'Not Found'
   },
   SettingPanel: {
     newContact: 'New Contact',
@@ -98,9 +97,6 @@ export default {
     pleaseType: 'Please be more creative',
     bio: 'Bio',
     bioHint: 'Short biolography displayed to others',
-    minimumStamp: 'Minimum Stamp *',
-    minimumStampHint: 'The minimum fee required for strangers to message you',
-    minimumStampRule: 'Please input an inbox fee',
     uploadAvatar: 'Upload Avatar'
   },
   clearHistoryDialog: {

--- a/src/pages/AddContact.vue
+++ b/src/pages/AddContact.vue
@@ -68,9 +68,6 @@
           </q-item-section>
           <q-item-section>
             <q-item-label>{{ contact.profile.name }}</q-item-label>
-            <q-item-label caption>
-              {{ $t('newContactDialog.minimumStamp') }}: {{ contact.inbox.acceptancePrice }}
-            </q-item-label>
           </q-item-section>
         </q-item>
       </q-card-section>


### PR DESCRIPTION
This was added for a demo of the app, and people keep getting confused
by it. So, remove it for now until there is some support for
notification thresholds and configuration thereof.
