### PR TITLE
Fix Threshold filtering on Forum

### DIFF
--- a/src/components/panels/ForumDrawer.vue
+++ b/src/components/panels/ForumDrawer.vue
@@ -133,7 +133,9 @@ export default defineComponent({
     },
     threshold: {
       set (newVal?: string) {
-        this.setVoteThreshold(newVal ?? '')
+        const threshold = Number.parseFloat(newVal ?? '0')
+        const newThreshold = Number.isNaN(threshold) ? 0 : threshold
+        this.setVoteThreshold(newThreshold)
       },
       get (): string {
         return this.getVoteThreshold

--- a/src/pages/Forum.vue
+++ b/src/pages/Forum.vue
@@ -43,7 +43,7 @@ export default defineComponent({
       voteThreshold: 'forum/getVoteThreshold'
     }),
     sortedPosts () {
-      return sortPostsByMode(this.messages, this.sortMode).filter(msg => msg.satoshis * 1_000_000 >= this.voteThreshold)
+      return sortPostsByMode(this.messages, this.sortMode).filter(msg => msg.satoshis >= this.voteThreshold * 1_000_000)
     }
   }
 })


### PR DESCRIPTION
Seemed to be working due to default threshold being 0, but it actually
was not being properly parsed as a number when input. Additionally,
the filter was multiplying the post value by 1 million, rather than
the selected threshold.
