### PR TITLE
Enable configuration for a "compact mode"

### DIFF
--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -68,7 +68,7 @@
           </q-card-section>
           <q-card-section
             class="q-ma-none q-px-sm q-pt-none q-pb-sm col-grow"
-            v-if="renderBody"
+            v-if="renderBody && !compactView"
           >
             <span
               class="mdstyle"
@@ -171,6 +171,10 @@ export default defineComponent({
       type: Boolean
     },
     compact: {
+      default: false,
+      type: Boolean
+    },
+    compactView: {
       default: false,
       type: Boolean
     }

--- a/src/components/panels/ForumDrawer.vue
+++ b/src/components/panels/ForumDrawer.vue
@@ -56,6 +56,13 @@
             to="/new-post"
           />
         </q-item>
+        <q-item>
+          <q-checkbox
+            v-model="compactView"
+            class="q-mx-sm q-pa-sm"
+            label="Compact View"
+          />
+        </q-item>
       </q-list>
     </q-scroll-area>
   </div>
@@ -87,7 +94,8 @@ export default defineComponent({
       setSelectedTopic: 'forum/setSelectedTopic',
       setSortMode: 'forum/setSortMode',
       setDuration: 'forum/setDuration',
-      setVoteThreshold: 'forum/setVoteThreshold'
+      setVoteThreshold: 'forum/setVoteThreshold',
+      setCompactView: 'forum/setCompactView'
     }),
     refreshContent () {
       this.refreshMessages({ wallet: this.$wallet, topic: this.selectedTopic })
@@ -103,7 +111,9 @@ export default defineComponent({
       getSelectedTopic: 'forum/getSelectedTopic',
       getSortMode: 'forum/getSortMode',
       getDuration: 'forum/getDuration',
-      getVoteThreshold: 'forum/getVoteThreshold'
+      getVoteThreshold: 'forum/getVoteThreshold',
+      getCompactView: 'forum/getCompactView'
+
     }),
     sortMode: {
       set (newVal?: string) {
@@ -129,6 +139,14 @@ export default defineComponent({
       },
       get (): {label: string, value: number} | undefined {
         return DURATIONS.find((duration) => duration.value === this.getDuration)
+      }
+    },
+    compactView: {
+      set (newVal?: boolean) {
+        this.setCompactView(newVal)
+      },
+      get (): boolean {
+        return this.getCompactView
       }
     },
     threshold: {

--- a/src/pages/Forum.vue
+++ b/src/pages/Forum.vue
@@ -9,6 +9,7 @@
       :message="message"
       :show-parent="true"
       :show-replies="false"
+      :compact-view="compactView"
     />
   </template>
 </template>
@@ -40,7 +41,8 @@ export default defineComponent({
       sortMode: 'forum/getSortMode',
       topics: 'forum/getTopics',
       selectedTopic: 'forum/getSelectedTopic',
-      voteThreshold: 'forum/getVoteThreshold'
+      voteThreshold: 'forum/getVoteThreshold',
+      compactView: 'forum/getCompactView'
     }),
     sortedPosts () {
       return sortPostsByMode(this.messages, this.sortMode).filter(msg => msg.satoshis >= this.voteThreshold * 1_000_000)

--- a/src/store/modules/forum.ts
+++ b/src/store/modules/forum.ts
@@ -19,6 +19,7 @@ export type State = {
   sortMode: SortMode,
   duration: number,
   voteThreshold: number,
+  compactView: boolean,
 };
 
 const module: Module<State, unknown> = {
@@ -31,7 +32,8 @@ const module: Module<State, unknown> = {
     sortMode: 'hot',
     // 1 week
     duration: 1000 * 60 * 60 * 24 * 7,
-    voteThreshold: 0
+    voteThreshold: 0,
+    compactView: false
   },
   getters: {
     getMessages (state) {
@@ -63,6 +65,9 @@ const module: Module<State, unknown> = {
     },
     getVoteThreshold (state) {
       return state.voteThreshold
+    },
+    getCompactView (state) {
+      return state.compactView
     }
   },
   mutations: {
@@ -74,6 +79,9 @@ const module: Module<State, unknown> = {
     },
     setVoteThreshold (state, voteThreshold: number) {
       state.voteThreshold = voteThreshold
+    },
+    setCompactView (state, compactView: boolean) {
+      state.compactView = compactView
     },
     setEntries (state, messages: ForumMessage[]) {
       const newMessages = messages.filter((m) => !(m.payloadDigest in state.index)).map(m => ({ ...m, replies: [] }))


### PR DESCRIPTION
Currently, this setting just disables showing post bodies; but in
the future it could be changed to allow a totally different view
of Forum posts when in compact mode.
