### PR TITLE
Toolbar for electron build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@capacitor/core": "2.5.0",
+    "@electron/remote": "^2.0.1",
     "@quasar/extras": "^1.11.5",
     "@vue/compiler-sfc": "^3.2.4",
     "atob": "^2.1.2",

--- a/src-electron/electron-main.js
+++ b/src-electron/electron-main.js
@@ -106,20 +106,12 @@ function createWindow () {
   })
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    externalUrlWindow = new BrowserWindow({
-      width: 1000,
-      height: 600,
-      icon: nativeIcon,
-      frame: true,
-      useContentSize: true,
-      webPreferences: {
-        preload: path.resolve(__dirname, process.env.QUASAR_ELECTRON_PRELOAD),
-        contextIsolation: true,
-        nodeIntegration: true,
-        enableRemoteModule: true,
-      }
-    })
+    externalUrlWindow = new BrowserWindow()
     externalUrlWindow.loadURL(url)
+
+    // we pass 'deny' to disallow the creation of new window
+    // with mainWindow and instead manually use externalUrlWindow.
+    // Passing 'allow' will open link in two windows.
     return { action: 'deny' }
   })
 }

--- a/src-electron/electron-main.js
+++ b/src-electron/electron-main.js
@@ -36,6 +36,7 @@ function getIconPNGPath () {
 }
 
 let mainWindow
+let externalUrlWindow
 let tray
 let windowsBadgeUpdater
 const nativeIconSmall = nativeImage.createFromPath(getIconPNGPath()).resize({ width: 16, height: 16 })
@@ -104,11 +105,22 @@ function createWindow () {
     mainWindow = null
   })
 
-  mainWindow.webContents.on('will-navigate', (e, url) => {
-    if (url !== e.sender.getURL()) {
-      e.preventDefault()
-      shell.openExternal(url)
-    }
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    externalUrlWindow = new BrowserWindow({
+      width: 1000,
+      height: 600,
+      icon: nativeIcon,
+      frame: true,
+      useContentSize: true,
+      webPreferences: {
+        preload: path.resolve(__dirname, process.env.QUASAR_ELECTRON_PRELOAD),
+        contextIsolation: true,
+        nodeIntegration: true,
+        enableRemoteModule: true,
+      }
+    })
+    externalUrlWindow.loadURL(url)
+    return { action: 'deny' }
   })
 }
 

--- a/src-electron/electron-main.js
+++ b/src-electron/electron-main.js
@@ -4,6 +4,10 @@ import { app, BrowserWindow, nativeTheme, Tray, Menu, shell, nativeImage } from 
 import path from 'path'
 import fs from 'fs'
 import Badge from 'electron-windows-badge'
+import { initialize, enable } from '@electron/remote/main'
+
+// required for custom qbar
+initialize()
 
 // Enable single instance lock
 const isSingleInstance = app.requestSingleInstanceLock()
@@ -61,6 +65,7 @@ function createWindow () {
     width: 1000,
     height: 600,
     icon: nativeIcon,
+    frame: false,
     useContentSize: true,
     webPreferences: {
       preload: path.resolve(__dirname, process.env.QUASAR_ELECTRON_PRELOAD),
@@ -70,9 +75,13 @@ function createWindow () {
     }
   })
 
+  // custom qbar enabler
+  enable(mainWindow.webContents)
+
   windowsBadgeUpdater = new Badge(mainWindow, {})
 
   mainWindow.loadURL(process.env.APP_URL)
+  mainWindow.setMenuBarVisibility(false)
 
   let forceQuit = false
   if (process.platform === 'darwin') {

--- a/src-electron/electron-preload.js
+++ b/src-electron/electron-preload.js
@@ -17,6 +17,7 @@
  */
 
 import { contextBridge, ipcRenderer, shell } from 'electron'
+import { BrowserWindow } from '@electron/remote'
 
 contextBridge.exposeInMainWorld('badge',
   {
@@ -28,6 +29,26 @@ contextBridge.exposeInMainWorld('badge',
     }
   }
 )
+
+contextBridge.exposeInMainWorld('myWindowAPI', {
+  minimize () {
+    BrowserWindow.getFocusedWindow().minimize()
+  },
+
+  toggleMaximize () {
+    const win = BrowserWindow.getFocusedWindow()
+
+    if (win.isMaximized()) {
+      win.unmaximize()
+    } else {
+      win.maximize()
+    }
+  },
+
+  close () {
+    BrowserWindow.getFocusedWindow().close()
+  }
+})
 
 contextBridge.exposeInMainWorld('url',
   {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -3,7 +3,7 @@
     <q-header class="electron-only">
       <q-bar
         style="height: 23px"
-        class="q-electron-drag"
+        class="q-electron-drag q-pr-xs"
       >
         <q-space />
         <q-btn

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,5 +1,35 @@
 <template>
   <q-layout view="hHr LpR lff">
+    <q-header>
+      <q-bar
+        style="height: 23px"
+        class="q-electron-drag"
+      >
+        <q-space />
+        <q-btn
+          dense
+          size="xs"
+          flat
+          icon="minimize"
+          @click="minimize"
+        />
+        <q-btn
+          dense
+          size="xs"
+          flat
+          icon="crop_square"
+          @click="toggleMaximize"
+        />
+        <q-btn
+          dense
+          size="xs"
+          flat
+          icon="close"
+          @click="closeApp"
+        />
+      </q-bar>
+    </q-header>
+
     <q-drawer
       v-model="myDrawerOpen"
       :width="splitterRatio"
@@ -61,6 +91,21 @@ export default {
       getSortedChatOrder: 'chats/getSortedChatOrder',
       getDarkMode: 'appearance/getDarkMode'
     }),
+    minimize () {
+      if (process.env.MODE === 'electron') {
+        window.myWindowAPI.minimize()
+      }
+    },
+    toggleMaximize () {
+      if (process.env.MODE === 'electron') {
+        window.myWindowAPI.toggleMaximize()
+      }
+    },
+    closeApp () {
+      if (process.env.MODE === 'electron') {
+        window.myWindowAPI.close()
+      }
+    },
     tweak (offset, viewportHeight) {
       const height = viewportHeight - offset + 'px'
       return { height, minHeight: height }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout view="hHr LpR lff">
-    <q-header>
+    <q-header class="electron-only">
       <q-bar
         style="height: 23px"
         class="q-electron-drag"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,6 +1038,11 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
+"@electron/remote@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.1.tgz#810cbc595a21f0f94641eb2d7e8264063a3f84de"
+  integrity sha512-bGX4/yB2bPZwXm1DsxgoABgH0Cz7oFtXJgkerB8VrStYdTyvhGAULzNLRn9rVmeAuC3VUDXaXpZIlZAZHpsLIA==
+
 "@electron/universal@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.0.5.tgz#b812340e4ef21da2b3ee77b2b4d35c9b86defe37"


### PR DESCRIPTION
Custom toolbar makes stamp for desktop look more elegant. 

New package is added to the project via `yarn add @electron/remote`

based on -> https://quasar.dev/quasar-cli/developing-electron-apps/frameless-electron-window#minimize-maximize-and-close-app

Minimize, maximize, close and move around work as expected.

Not showing on other platforms via "electron-only" class. 

![Screenshot from 2021-11-15 15-01-42](https://user-images.githubusercontent.com/11517372/141794785-7f51a8b1-946f-4b32-a6e4-c8d0507c1a02.png)


