### PR TITLE
Give topic hints to user when posting

### DIFF
--- a/src/store/modules/forum.ts
+++ b/src/store/modules/forum.ts
@@ -127,6 +127,9 @@ const module: Module<State, unknown> = {
     },
     setSelectedTopic (state, topic: string) {
       state.selectedTopic = topic
+    },
+    pushNewTopic (state, topic: string) {
+      state.topics.push(topic)
     }
   },
   actions: {


### PR DESCRIPTION
@schancel : 
"People are entering lots of random topics and sometimes mistyping
existing ones. This commit switches the topic input on the CreatePost
screen to be a QSelect with all the known topics available. It also
allows for manually specifying a new topic, however it is preferable
to keep posts within known topics."

This is same code/branch as https://github.com/StampChat/stamp/pull/469

There were some conflicts with that branch so I made a new one from current master.

There was a bug in that branch where after user created a post and came back there was no topics available. Not sure if it was caching error or some new commits to master fixed it, but it works fine now.

Adding new topic works with clicking on it or pushing enter or tab. 

It doesn't work when you just type it and click outside, but it seems to be a behavior consistent with how quasar developers intended it to work. 


https://user-images.githubusercontent.com/11517372/141801838-d6c0d5b8-bfee-4f8b-be3f-53be863b03a3.mp4


  