### PR TITLE
Add spinner at forum page before posts are loaded.

### DIFF
--- a/src/pages/Forum.vue
+++ b/src/pages/Forum.vue
@@ -1,16 +1,27 @@
 <template>
-  <template
-    v-for="(message) in sortedPosts"
-    :key="message.payloadDigest"
-  >
-    <a-message
-      v-show="showMessage(message.topic)"
-      @set-topic="(...args) => $emit('set-topic', ...args)"
-      :message="message"
-      :show-parent="true"
-      :show-replies="false"
-      :compact-view="compactView"
-    />
+  <template v-if="messages.length > 0">
+    <template
+      v-for="(message) in sortedPosts"
+      :key="message.payloadDigest"
+    >
+      <a-message
+        v-show="showMessage(message.topic)"
+        @set-topic="(...args) => $emit('set-topic', ...args)"
+        :message="message"
+        :show-parent="true"
+        :show-replies="false"
+        :compact-view="compactView"
+      />
+    </template>
+  </template>
+  <template v-else>
+    <div>
+      <q-spinner-puff
+        class="absolute-center"
+        color="purple"
+        size="20rem"
+      />
+    </div>
   </template>
 </template>
 


### PR DESCRIPTION
There is short period of time where user opens an app and forum is still loading posts. 

Temporary solution is to add a spinner in this place. 

Different spinner can be picked here -> https://quasar.dev/vue-components/spinners#example--other-spinners

Spinner color and size can be customized.

Current one is:

https://user-images.githubusercontent.com/11517372/142004504-2ea9c48b-107d-42b9-93a4-23585cffe495.mp4



