### PR TITLE
Allow `Buffer` in `Script.buildPublicKeyHashOut`

### DIFF
--- a/local_modules/bitcore-lib-xpi/lib/script/script.js
+++ b/local_modules/bitcore-lib-xpi/lib/script/script.js
@@ -864,20 +864,20 @@ Script.buildP2SHMultisigIn = function(pubkeys, threshold, signatures, opts) {
 /**
  * @returns {Script} a new pay to public key hash output for the given
  * address or public key
- * @param {(Address|PublicKey)} to - destination address or public key
+ * @param {(Address|PublicKey|Buffer=)} to - destination address, public key or public key hash
  */
 Script.buildPublicKeyHashOut = function(to) {
   $.checkArgument(!_.isUndefined(to));
-  $.checkArgument(to instanceof PublicKey || to instanceof Address || _.isString(to));
-  if (to instanceof PublicKey) {
-    to = to.toAddress();
-  } else if (_.isString(to)) {
-    to = new Address(to);
-  }
+  $.checkArgument(to instanceof PublicKey || to instanceof Address || to instanceof Buffer || _.isString(to));
+  var buffer =
+    to instanceof Buffer ? to :
+    to instanceof Address ? to.hashBuffer :
+    to instanceof PublicKey ? to.toAddress().hashBuffer :
+    _.isString(to) ? new Address(to).hashBuffer : undefined;
   var s = new Script();
   s.add(Opcode.OP_DUP)
     .add(Opcode.OP_HASH160)
-    .add(to.hashBuffer)
+    .add(buffer)
     .add(Opcode.OP_EQUALVERIFY)
     .add(Opcode.OP_CHECKSIG);
   s._network = to.network;

--- a/local_modules/bitcore-lib-xpi/test/script/script.js
+++ b/local_modules/bitcore-lib-xpi/test/script/script.js
@@ -762,6 +762,14 @@ describe('Script', function() {
       should.exist(s._network);
       s._network.should.equal(pubkey.network);
     });
+    it('should create P2PKH script from buffer', function() {
+      const hash = Buffer.from('0123456789012345678901234567890123456789', 'hex');
+      var s = Script.buildPublicKeyHashOut(hash);
+      should.exist(s);
+      s.toString().should.equal('OP_DUP OP_HASH160 20 0x0123456789012345678901234567890123456789 OP_EQUALVERIFY OP_CHECKSIG');
+      s.isPublicKeyHashOut().should.equal(true);
+      s.toAddress().toString().should.equal('lotus_16PSJH9V9yzfUx9Kq9XrUYqB6S9o94vt861cVakbb');
+    });
   });
   describe('#buildPublicKeyOut', function() {
     it('should create script from public key', function() {

--- a/src/types/bitcore-lib-xpi/bitcore-lib-xpi.d.ts
+++ b/src/types/bitcore-lib-xpi/bitcore-lib-xpi.d.ts
@@ -244,7 +244,7 @@ declare module 'bitcore-lib-xpi' {
       opts: unknown,
     ): Script
     function buildPublicKeyHashOut(
-      address: Address | PublicKey | string,
+      address: Address | PublicKey | Buffer | string,
     ): Script
     function buildPublicKeyOut(pubkey: PublicKey): Script
     function buildDataOut(data: string | Buffer, encoding?: string): Script


### PR DESCRIPTION
Make `buildPublicKeyHashOut` accept a `Buffer`, to specify the public key hash directly.