### PR TITLE
Check UTXOs with Chronik Indexer's `validateUtxos`

### DIFF
--- a/src/cashweb/keyserver/handler.ts
+++ b/src/cashweb/keyserver/handler.ts
@@ -319,7 +319,7 @@ export class KeyserverHandler {
         ),
       )
     } catch (err) {
-      await Promise.all(usedUtxos.map(utxo => this.wallet?.fixUtxo(utxo)))
+      await this.wallet?.fixUtxos(usedUtxos)
       throw err
     }
     return payloadDigest.toString('hex')

--- a/src/cashweb/relay/index.ts
+++ b/src/cashweb/relay/index.ts
@@ -575,11 +575,8 @@ export class RelayClient extends ReadOnlyRelayClient {
       // Ensure all outpoints are on-chain before trying to send message. Don't
       // want to burn other transactions if our state is out of sync with the
       // blockchain.
-      Promise.all(
-        stagedUtxos.map(async outpoint => {
-          return wallet.checkOutpoint(outpoint)
-        }),
-      )
+      wallet
+        .checkAndFixUtxos(stagedUtxos)
         .then(checks => checks.every(c => c))
         .then(o => {
           if (!o) {


### PR DESCRIPTION
Currently, this is done through a potentially expensive `listunspent` call to Electrum. Chronik gives us the state of a list of UTXOs directly with a single call, which is much faster.
