### PR TITLE
Use Chronik Indexer to broadcast txs

### DIFF
--- a/src/cashweb/relay/index.ts
+++ b/src/cashweb/relay/index.ts
@@ -570,8 +570,8 @@ export class RelayClient extends ReadOnlyRelayClient {
       const destinationAddress = destinationPublicKey
         .toAddress(this.networkName)
         .toCashAddress()
-      const electrumClient = await this.wallet?.electrumClientPromise
-      assert(electrumClient, 'Unable to get electrumClient')
+      const chronikClient = this.wallet?.chronikClient
+      assert(chronikClient, 'Unable to get chronikClient')
       // Ensure all outpoints are on-chain before trying to send message. Don't
       // want to burn other transactions if our state is out of sync with the
       // blockchain.
@@ -593,10 +593,7 @@ export class RelayClient extends ReadOnlyRelayClient {
                 transaction.txid,
                 transaction.toString(),
               )
-              await electrumClient.request(
-                'blockchain.transaction.broadcast',
-                transaction.toString(),
-              )
+              await chronikClient.broadcastTx(transaction.toString())
               console.log('Finished broadcasting tx', transaction.txid)
             }),
           ),

--- a/src/cashweb/wallet/index.ts
+++ b/src/cashweb/wallet/index.ts
@@ -420,9 +420,10 @@ export class Wallet {
     console.log('Broadcasting forwarding txn', transaction)
     const txHex = transaction.toString()
     try {
-      const electrumClient = await this.electrumClientPromise
-      assert(electrumClient, 'missing client in forwardUTXOsToAddress')
-      await electrumClient.request('blockchain.transaction.broadcast', txHex)
+      const chronikClient = this.chronikClient
+      assert(chronikClient, 'missing client in forwardUTXOsToPubkey')
+      const broadcastResult = await chronikClient.broadcastTx(txHex)
+      console.log('Successfully broadcast tx', broadcastResult.txid)
       // TODO: we shouldn't be dealing with this here. Leaky abstraction
       stagedUtxos.map(utxo => this.storage.deleteById(calcUtxoId(utxo)))
     } catch (err) {


### PR DESCRIPTION
Currently, we use Electrum to broadcast txs. However, this apparently sometimes silently drops txs, and it also doesn't verify that the transaction doesn't burn SLP tokens.
Using Chronik, this is no longer a problem.