### PR TITLE
Rename `$electrum` Vue observable to `$indexer`

### DIFF
--- a/src/adapters/vuex-relay-adapter.js
+++ b/src/adapters/vuex-relay-adapter.js
@@ -5,12 +5,11 @@ import { toRaw, reactive } from 'vue'
 
 export async function getRelayClient({
   wallet,
-  electrumClient,
   store,
   relayUrl = defaultRelayUrl,
 }) {
   const observables = reactive({ connected: false })
-  const client = new RelayClient(relayUrl, wallet, electrumClient, {
+  const client = new RelayClient(relayUrl, wallet, {
     getPubKey: address => {
       const destPubKey = store.getters['contacts/getPubKey'](address)
       return destPubKey

--- a/src/boot/setup-apis.ts
+++ b/src/boot/setup-apis.ts
@@ -212,10 +212,10 @@ async function getWalletClient({ store }: { store: Store<any> }) {
 export default boot<RootState>(async ({ store, app }) => {
   await (store as any).restored
   const wallet = await getWalletClient({ store })
-  const electrumObservables = reactive({ connected: false })
+  const indexerObservables = reactive({ connected: false })
   createAndBindNewIndexerClient({
     app,
-    observables: electrumObservables,
+    observables: indexerObservables,
     wallet,
   })
   const xPrivKey = store.getters['wallet/getXPrivKey']
@@ -239,7 +239,6 @@ export default boot<RootState>(async ({ store, app }) => {
     await getRelayClient({
       relayUrl: defaultRelayUrl,
       wallet,
-      electrumClient: app.config.globalProperties.$electrumClientPromise,
       store,
     })
   const relayToken: string = store.getters['relayClient/getToken']
@@ -247,7 +246,7 @@ export default boot<RootState>(async ({ store, app }) => {
   relayClient.setToken(relayToken)
 
   app.config.globalProperties.$wallet = wallet
-  app.config.globalProperties.$electrum = electrumObservables
+  app.config.globalProperties.$indexer = indexerObservables
   app.config.globalProperties.$relayClient = relayClient
   app.config.globalProperties.$relay = relayObservables
 })

--- a/src/cashweb/relay/index.ts
+++ b/src/cashweb/relay/index.ts
@@ -34,7 +34,6 @@ import {
   Address,
   PrivateKey,
 } from 'bitcore-lib-xpi'
-import type { ElectrumClient } from 'electrum-cash'
 import { MessageStore } from './storage/storage'
 import { Wallet } from '../wallet'
 import {
@@ -160,7 +159,6 @@ export class RelayClient extends ReadOnlyRelayClient {
   url: string
   events: EventEmitter
   wallet?: Wallet
-  electrumClientPromise: Promise<ElectrumClient>
   getPubKey: (address: string) => PublicKey
   messageStore: MessageStore
   relayReconnectInterval: number
@@ -171,7 +169,6 @@ export class RelayClient extends ReadOnlyRelayClient {
   constructor(
     url: string,
     wallet: Wallet,
-    electrumClientPromise: Promise<ElectrumClient>,
     {
       networkName = 'testnet',
       relayReconnectInterval = 10_000,
@@ -193,7 +190,6 @@ export class RelayClient extends ReadOnlyRelayClient {
     this.url = url
     this.events = new EventEmitter()
     this.wallet = wallet
-    this.electrumClientPromise = electrumClientPromise
     this.getPubKey = getPubKey
     this.messageStore = messageStore
     this.relayReconnectInterval = relayReconnectInterval

--- a/src/components/StatusFooter.vue
+++ b/src/components/StatusFooter.vue
@@ -24,7 +24,7 @@ export default {
   },
   computed: {
     connected() {
-      return this.$electrum.connected
+      return this.$indexer.connected
     },
   },
 }

--- a/src/components/panels/LeftDrawer.vue
+++ b/src/components/panels/LeftDrawer.vue
@@ -19,9 +19,7 @@
       <q-item clickable>
         <q-item-section @click="receiveECash">
           <q-item-label>{{ $t('chatList.balance') }}</q-item-label>
-          <q-item-label caption>
-            {{ formattedBalance }}
-          </q-item-label>
+          <q-item-label caption>{{ formattedBalance }}</q-item-label>
         </q-item-section>
         <q-item-section v-if="!walletConnected" side>
           <q-btn icon="account_balance_wallet" flat round color="red" />
@@ -118,7 +116,7 @@ export default {
       return this.$relay.connected
     },
     walletConnected() {
-      return this.$electrum.connected
+      return this.$indexer.connected
     },
     formattedBalance() {
       if (!this.balance) {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -145,8 +145,8 @@ export default {
       // const lastReceived = this.lastReceived
       const t0 = performance.now()
       const refreshMessages = () => {
-        // Wait for a connected electrum client
-        if (!this.$electrum.connected) {
+        // Wait for a connected blockchain client
+        if (!this.$indexer.connected) {
           setTimeout(refreshMessages, 100)
           return
         }

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -66,9 +66,9 @@
                 class="q-ml-sm"
               />
             </q-stepper-navigation>
-            <q-banner inline-actions class="text-white bg-red">
-              {{ $t('setup.seedWarning') }}
-            </q-banner>
+            <q-banner inline-actions class="text-white bg-red">{{
+              $t('setup.seedWarning')
+            }}</q-banner>
           </template>
         </q-stepper>
       </q-page>
@@ -251,7 +251,6 @@ export default defineComponent({
         relayUrl: this.relayUrl,
         store: this.$store,
         wallet: this.$wallet,
-        electrumClient: this.$electrum,
       })
       try {
         this.relayData = await relayClient.getRelayData(idAddress)
@@ -305,7 +304,6 @@ export default defineComponent({
       const { client: relayClient } = await getRelayClient({
         relayUrl: this.relayUrl,
         store: this.$store,
-        electrumClient: this.$electrumClientPromise,
         wallet: this.$wallet,
       })
 
@@ -448,7 +446,7 @@ export default defineComponent({
   computed: {
     ...mapGetters({ balance: 'wallet/balance' }),
     forwardEnabled() {
-      if (!this.$electrum.connected) {
+      if (!this.$indexer.connected) {
         return false
       }
       console.log('isWalletValid', this.isWalletValid)

--- a/src/types/vue.d.ts
+++ b/src/types/vue.d.ts
@@ -8,7 +8,7 @@ declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     // Vuejs props
     // Stamp properties
-    $electrum: {
+    $indexer: {
       connected: boolean
     }
     $electrumClientPromise: Promise<ElectrumClient>


### PR DESCRIPTION
Makes the code independent of used indexer. Currently, `$electrum` only has a `connected` field.
