### PR TITLE
Remove Electrum from codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "core-js": "^3.19.2",
     "dompurify": "^2.3.1",
     "electron-windows-badge": "^1.1.0",
-    "electrum-cash": "^2.0.9",
     "google-protobuf": "^3.19.1",
     "isomorphic-ws": "^4.0.1",
     "level": "^7.0.0",

--- a/src/types/vue.d.ts
+++ b/src/types/vue.d.ts
@@ -1,4 +1,3 @@
-import { ElectrumClient } from 'electrum-cash'
 import RelayClient from 'src/cashweb/relay'
 import { Wallet } from 'src/cashweb/wallet'
 import { RootState } from 'src/store/modules'
@@ -11,7 +10,6 @@ declare module '@vue/runtime-core' {
     $indexer: {
       connected: boolean
     }
-    $electrumClientPromise: Promise<ElectrumClient>
 
     $wallet: Wallet
     $relayClient: RelayClient

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,15 +1,3 @@
-import { ElectrumTransport } from 'electrum-cash'
-
-// Electrum constants
-export const electrumServers = [
-  // Our mainnet server, we need to setup a testnet server as well.
-  {
-    url: 'fulcrum.cashweb.io',
-    port: 443,
-    scheme: ElectrumTransport.WSS.Scheme,
-  },
-]
-
 export const chronikServers = [{ url: 'https://chronik.be.cash/xpi' }]
 
 // The separation here is due the fork. Not all backends support the new network prefixes yet
@@ -17,8 +5,6 @@ export const chronikServers = [{ url: 'https://chronik.be.cash/xpi' }]
 // the ecash prefix for display
 export const networkName = 'cash-livenet'
 export const displayNetwork = 'livenet'
-
-export const electrumPingInterval = 10_000
 
 // Wallet constants
 export const numAddresses = 10

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,13 +1757,6 @@
     http-proxy-middleware "^2.0.0"
     webpack "*"
 
-"@types/ws@^7.4.6":
-  version "7.4.7"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
-  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ws@^8.2.1":
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.2.tgz#7c5be4decb19500ae6b3d563043cd407bf366c21"
@@ -2395,13 +2388,6 @@ async-exit-hook@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
   integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
-
-async-mutex@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
-  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
-  dependencies:
-    tslib "^2.3.1"
 
 async@0.9.x:
   version "0.9.2"
@@ -4146,17 +4132,6 @@ electron@^16.0.4:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
-
-electrum-cash@^2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-2.0.9.tgz#3031ed958549a5fee8e8b9f2b909671817636296"
-  integrity sha512-3hM75PJ5+JyeFL2Fzs7thnhPX22fI1uG5XfVTE27DxdMUqWYiK7yC1HSqoayDWDwJrZLd+2LJP5ur4OmcwFSnA==
-  dependencies:
-    "@types/ws" "^7.4.6"
-    async-mutex "^0.3.1"
-    debug "^4.3.2"
-    isomorphic-ws "^4.0.1"
-    ws "^7.5.2"
 
 elementtree@0.1.7:
   version "0.1.7"
@@ -8865,7 +8840,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1:
+tslib@^2.0.3, tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -9692,7 +9667,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.3.1, ws@^7.5.2:
+ws@^7.3.1:
   version "7.5.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
   integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==


### PR DESCRIPTION
All instances where an Electrum client is required have been replaced by Chronik, therefore we can remove all occurances of Electrum from the codebase now.
