### PR TITLE
Direct Message UX

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -81,8 +81,8 @@
         class="full-width q-pl-md"
         dense
         borderless
-        autogrow
         autofocus
+        autogrow
         @keydown.enter.exact.prevent
         @keydown.enter.exact="sendMessage"
         @mousedown.self.stop
@@ -132,7 +132,7 @@ export default {
   },
   emits: ['update:message', 'update:stampAmount', 'sendMessage', 'giveLotusClicked', 'sendFileClicked'],
   methods: {
-    focus () {
+    focusInput () {
       this.$refs.inputBox.focus()
     },
     sendMessage () {

--- a/src/components/chat/messages/ChatMessage.vue
+++ b/src/components/chat/messages/ChatMessage.vue
@@ -66,9 +66,9 @@
           #stamp
         >
           <chat-message-suffix
+            :status="message.status"
             :stamp="reactiveTimestamp"
             :amount="stampAmount"
-            :status="message.status"
           />
         </template>
       </q-chat-message>
@@ -94,9 +94,9 @@
           #stamp
         >
           <chat-message-suffix
+            :status="message.status"
             :stamp="reactiveTimestamp"
             :amount="stampAmount"
-            :status="message.status"
           />
         </template>
       </q-chat-message>
@@ -181,16 +181,6 @@ export default {
           // return moment(timestamp).fromNow(true)
           const howLongAgo = moment(timestamp)
           return howLongAgo.fromNow(true)
-          /*
-          return howLongAgo.calendar(null, {
-            sameDay: 'HH:mm:ss',
-            nextDay: '[Tomorrow] HH:mm:ss',
-            nextWeek: 'dddd',
-            lastDay: 'HH:mm:ss',
-            lastWeek: '[Last] dddd',
-            sameElse: 'DD/MM/YYYY'
-          })
-          */
         }
         case 'pending':
           return 'sending...'
@@ -217,42 +207,6 @@ export default {
     replyItem () {
       // return empty payloadDigest string if reply doesn't exist
       return this.message.items.find(item => item.type === 'reply') || { payloadDigest: '' }
-    },
-    shortTimestamp () {
-      switch (this.message.status) {
-        case 'confirmed': {
-          const timestamp = this.messageTimestamp || this.message.serverTime
-          // return moment(timestamp).fromNow(true)
-          const howLongAgo = moment(timestamp)
-          return howLongAgo.calendar(null, {
-            sameDay: 'HH:mm:ss',
-            nextDay: '[Tomorrow] HH:mm:ss',
-            nextWeek: 'dddd',
-            lastDay: 'HH:mm:ss',
-            lastWeek: '[Last] dddd',
-            sameElse: 'DD/MM/YYYY'
-          })
-        }
-        case 'pending':
-          return 'sending...'
-        case 'error':
-          return ''
-      }
-      return 'N/A'
-    },
-    shortTime () {
-      switch (this.message.status) {
-        case 'confirmed': {
-          const timestamp = this.message.timestamp || this.message.serverTime
-          const howLongAgo = moment(timestamp)
-          return howLongAgo.format('HH:mm:ss')
-        }
-        case 'pending':
-          return 'sending...'
-        case 'error':
-          return ''
-      }
-      return 'N/A'
     },
     stampAmount () {
       if (!this.message || !this.message.outpoints) {

--- a/src/components/chat/messages/ChatMessageImage.vue
+++ b/src/components/chat/messages/ChatMessageImage.vue
@@ -20,7 +20,6 @@ export default {
     },
     width: {
       type: String,
-      required: false,
       default: () => '300px'
     }
   },

--- a/src/components/chat/messages/ChatMessageImage.vue
+++ b/src/components/chat/messages/ChatMessageImage.vue
@@ -1,16 +1,12 @@
 <template>
-  <div class="q-ml-sm">
-    <q-dialog v-model="imageDialog">
-      <image-dialog :image="image" />
-    </q-dialog>
-
-    <q-img
-      :src="image"
-      contain
-      style="width: 10vw;"
-      @click="showImageDialog"
-    />
-  </div>
+  <q-dialog v-model="imageDialog">
+    <image-dialog :image="image" />
+  </q-dialog>
+  <q-img
+    :src="image"
+    :width="width"
+    @click="showImageDialog"
+  />
 </template>
 
 <script>
@@ -21,6 +17,11 @@ export default {
     image: {
       type: String,
       default: () => ''
+    },
+    width: {
+      type: String,
+      required: false,
+      default: () => '300px'
     }
   },
   components: {

--- a/src/components/chat/messages/ChatMessageReply.vue
+++ b/src/components/chat/messages/ChatMessageReply.vue
@@ -3,7 +3,7 @@
     class="q-mb-sm q-px-sm q-py-sm"
     style="border-left: 4px solid black; background-color: rgba(0, 0, 0, 0.21);"
   >
-    <!-- Redundant to show for stealth messages -->
+    <!-- Redundant to show name for stealth messages -->
     <div
       v-show="messageType !== 'stealth'"
       class="row q-mt-xs q-py-xs"
@@ -46,16 +46,6 @@ export default {
     }
   },
   props: {
-    /*
-    address: {
-      type: String,
-      required: false
-    },
-    mouseover: {
-      type: Boolean,
-      required: false
-    },
-    */
     payloadDigest: {
       type: String,
       required: true
@@ -102,14 +92,7 @@ export default {
         return 'Not Found'
       }
       return contact.profile.name
-    }/* ,
-    nameColor () {
-      if (this.message.senderAddress === this.$wallet.myAddress.toXAddress()) {
-        return 'text-black'
-      }
-      return addressColorFromStr(this.address)
     }
-    */
   }
 }
 </script>

--- a/src/components/chat/messages/ChatMessageStack.vue
+++ b/src/components/chat/messages/ChatMessageStack.vue
@@ -1,4 +1,21 @@
 <template>
+  <div
+    class="row q-px-lg"
+    style="max-width: 720px"
+  >
+    <chat-message
+      v-for="(message, index) in messages"
+      :key="index"
+      :message="message"
+      :index="index + globalIndex"
+      :items="message.items"
+      :address="address"
+      :name-color="nameColor"
+      :name="contact.name"
+      @replyClicked="replyClicked"
+    />
+  </div>
+  <!--
   <div class="row">
     <div class="col">
       <div class="stack-header row">
@@ -24,12 +41,12 @@
           :items="message.items"
           :address="address"
           :name-color="nameColor"
-          :name="contact.name"
           @replyClicked="replyClicked"
         />
       </q-list>
     </div>
   </div>
+  -->
 </template>
 
 <script>
@@ -76,9 +93,10 @@ export default {
       const lastMessage = this.messages[nMessages - 1]
       return lastMessage
     },
-    shortTimestamp () {
-      const nMessages = this.messages.length
-      const lastMessage = this.messages[nMessages - 1]
+    lastTimestamp () {
+      // const nMessages = this.messages.length
+      // const lastMessage = this.messages[nMessages - 1]
+      const lastMessage = this.lastMessage
       switch (lastMessage.status) {
         case 'confirmed': {
           const timestamp = lastMessage.timestamp || lastMessage.serverTime

--- a/src/components/chat/messages/ChatMessageStack.vue
+++ b/src/components/chat/messages/ChatMessageStack.vue
@@ -15,45 +15,13 @@
       @replyClicked="replyClicked"
     />
   </div>
-  <!--
-  <div class="row">
-    <div class="col">
-      <div class="stack-header row">
-        <div
-          class="q-px-md col text-weight-bold"
-          :style="nameColor"
-        >
-          {{ contact.name }}
-        </div>
-        <div class="col-auto">
-          {{ stampAmount }}
-        </div>
-        <div class="q-px-sm col-auto">
-          {{ shortTimestamp }}
-        </div>
-      </div>
-      <q-list class="q-pt-sm">
-        <chat-message
-          v-for="(message, index) in messages"
-          :key="index"
-          :message="message"
-          :index="index + globalIndex"
-          :items="message.items"
-          :address="address"
-          :name-color="nameColor"
-          @replyClicked="replyClicked"
-        />
-      </q-list>
-    </div>
-  </div>
-  -->
 </template>
 
 <script>
-import moment from 'moment'
 import ChatMessage from './ChatMessage.vue'
-import { stampPrice } from '../../../cashweb/wallet/helpers'
-import { formatBalance } from '../../../utils/formatting'
+// import moment from 'moment'
+// import { stampPrice } from '../../../cashweb/wallet/helpers'
+// import { formatBalance } from '../../../utils/formatting'
 
 export default {
   components: {
@@ -86,7 +54,8 @@ export default {
     replyClicked (args) {
       this.$emit('replyClicked', args)
     }
-  },
+  }
+  /* ,
   computed: {
     lastMessage () {
       const nMessages = this.messages.length
@@ -127,6 +96,7 @@ export default {
       return formatBalance(amount)
     }
   }
+  */
 }
 </script>
 

--- a/src/components/chat/messages/ChatMessageStealth.vue
+++ b/src/components/chat/messages/ChatMessageStealth.vue
@@ -30,12 +30,6 @@ export default {
       required: true
     }
   },
-  data () {
-    return {
-      imageDialog: false,
-      image: null
-    }
-  },
   computed: {
     stealthDirection () {
       return this.outbound ? 'sent' : 'received'

--- a/src/components/chat/messages/ChatMessageStealth.vue
+++ b/src/components/chat/messages/ChatMessageStealth.vue
@@ -1,16 +1,19 @@
 <template>
-  <q-banner
-    rounded
-    class="bg-grey-3"
+  <div
+    class="q-mb-sm"
   >
-    You received
-    <q-icon
-      name="local_florist"
-      size="sm"
-      dense
-    />
-    {{ formatSats(amount) }}
-  </q-banner>
+    <q-banner
+      rounded
+      :class="[bannerColor, 'text-center']"
+    >
+      <q-icon
+        name="local_florist"
+        size="sm"
+      />
+      You {{ stealthDirection }}
+      {{ formatSats(amount) }}
+    </q-banner>
+  </div>
 </template>
 
 <script>
@@ -21,12 +24,29 @@ export default {
     amount: {
       type: Number,
       required: true
+    },
+    outbound: {
+      type: Boolean,
+      required: true
     }
   },
   data () {
     return {
       imageDialog: false,
       image: null
+    }
+  },
+  computed: {
+    stealthDirection () {
+      return this.outbound ? 'sent' : 'received'
+    },
+    // Better theme-based colors for stealth messages
+    bannerColor () {
+      if (this.$q.dark.isActive) {
+        return 'bg-grey-9'
+      } else {
+        return 'bg-grey-3'
+      }
     }
   },
   methods: {

--- a/src/components/chat/messages/ChatMessageSuffix.vue
+++ b/src/components/chat/messages/ChatMessageSuffix.vue
@@ -1,0 +1,44 @@
+<template>
+  <div
+    v-if="status === 'error'"
+  >
+    <q-icon
+      name="error"
+      color="red"
+    />
+  </div>
+  <div
+    v-else
+  >
+    <div>
+      <div class="col">
+        {{ stamp }}
+      </div>
+      <div class="col">
+        {{ amount }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+// import { defineComponent } from '@vue/composition-api'
+
+export default {
+  name: 'ChatMessageSuffix',
+  props: {
+    stamp: {
+      type: String,
+      required: true
+    },
+    amount: {
+      type: String,
+      required: true
+    },
+    status: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/components/chat/messages/ChatMessageText.vue
+++ b/src/components/chat/messages/ChatMessageText.vue
@@ -1,21 +1,21 @@
 <template>
-  <span v-html="markedMessage(text)" />
+  <span v-html="markedMessage" />
 </template>
 
 <script>
-import { toMarkdown } from '../../../utils/markdown'
+import { renderMarkdown } from '../../../utils/markdown'
 
 export default {
-  name: 'ChatMessageSection',
+  name: 'ChatMessageText',
   props: {
     text: {
       type: String,
       required: true
     }
   },
-  methods: {
-    markedMessage (text) {
-      return toMarkdown(text)
+  computed: {
+    markedMessage () {
+      return renderMarkdown(this.text)
     }
   }
 }

--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -47,8 +47,7 @@
             <q-icon
               name="link"
               v-if="entry.url"
-              size="18px"
-              class="q-pa-xs"
+              class="text-h6 q-pa-xs"
             />
             <a
               :href="entry.url"

--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -44,12 +44,20 @@
             horizontal
             class="q-ma-none q-pa-sm col-grow text-bold"
           >
+            <q-icon
+              name="link"
+              v-if="entry.url"
+              size="24px"
+              class="q-pa-xs"
+            />
             <a
               :href="entry.url"
               target="_blank"
               v-if="entry.url"
               class="text-h6 text-bold q-mr-md post-title"
-            >{{ entry.title || 'Untitled' }}</a>
+            >
+              {{ entry.title || 'Untitled' }}
+            </a>
             <span
               v-if="!entry.url"
               class="text-h6 text-bold q-mr-md"

--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -147,7 +147,7 @@
 </template>
 
 <script lang="ts">
-import { toMarkdown } from '../../utils/markdown'
+import { renderMarkdown } from '../../utils/markdown'
 import moment from 'moment'
 
 import { defineComponent } from 'vue'
@@ -202,7 +202,7 @@ export default defineComponent({
       return (value / 1_000_000).toFixed(0)
     },
     markedMessage (text: string) {
-      return toMarkdown(text)
+      return renderMarkdown(text)
     },
     formatAddress (address:string) {
       return address.substring(6, 12) + '...' + address.substring(address.length - 6, address.length)

--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -47,7 +47,7 @@
             <q-icon
               name="link"
               v-if="entry.url"
-              size="24px"
+              size="18px"
               class="q-pa-xs"
             />
             <a
@@ -55,9 +55,7 @@
               target="_blank"
               v-if="entry.url"
               class="text-h6 text-bold q-mr-md post-title"
-            >
-              {{ entry.title || 'Untitled' }}
-            </a>
+            >{{ entry.title || 'Untitled' }}</a>
             <span
               v-if="!entry.url"
               class="text-h6 text-bold q-mr-md"

--- a/src/layouts/ChatLayout.vue
+++ b/src/layouts/ChatLayout.vue
@@ -57,7 +57,7 @@
     </q-header>
 
     <q-page-container>
-      <q-page>
+      <q-page class="q-pt-xs">
         <router-view
           @sendFileClicked="sendFileOpen = true"
           @giveLotusClicked="sendMoneyOpen = true"

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -36,14 +36,11 @@
   <q-footer bordered>
     <div
       v-if="!!replyDigest"
-      class="reply col q-px-md q-pt-sm"
+      class="reply q-px-md q-pt-sm"
       ref="replyBox"
     >
       <!-- Reply box -->
-      <div class="row">
-        <div class="col text-weight-bold">
-          {{ replyName }}
-        </div>
+      <div class="row justify-end">
         <div class="col-auto">
           <q-btn
             dense
@@ -55,18 +52,12 @@
         </div>
       </div>
       <div class="row q-px-sm q-pt-sm">
-        <chat-message-text
-          v-if="replyItem.type=='text'"
-          :text="replyItem.text"
-        />
-        <chat-message-image
-          v-else-if="replyItem.type=='image'"
-          :image="replyItem.image"
-        />
-        <chat-message-stealth
-          v-else-if="replyItem.type=='stealth'"
-          :amount="replyItem.amount"
-        />
+        <div class="col-12">
+          <chat-message-reply
+            :payload-digest="replyDigest"
+            @replyMounted="replyMounted()"
+          />
+        </div>
       </div>
     </div>
 
@@ -86,9 +77,10 @@
 import { mapState, mapGetters, mapActions } from 'vuex'
 import ChatMessageStack from '../components/chat/messages/ChatMessageStack.vue'
 import ChatInput from '../components/chat/ChatInput.vue'
-import ChatMessageText from '../components/chat/messages/ChatMessageText.vue'
-import ChatMessageImage from '../components/chat/messages/ChatMessageImage.vue'
-import ChatMessageStealth from '../components/chat/messages/ChatMessageStealth.vue'
+import ChatMessageReply from '../components/chat/messages/ChatMessageReply.vue'
+// import ChatMessageText from '../components/chat/messages/ChatMessageText.vue'
+// import ChatMessageImage from '../components/chat/messages/ChatMessageImage.vue'
+// import ChatMessageStealth from '../components/chat/messages/ChatMessageStealth.vue'
 
 import { addressColorFromStr } from '../utils/formatting'
 import { insufficientStampNotify } from '../utils/notifications'
@@ -99,9 +91,10 @@ const scrollDuration = 0
 export default {
   components: {
     ChatMessageStack,
-    ChatMessageText,
-    ChatMessageImage,
-    ChatMessageStealth,
+    ChatMessageReply,
+    // ChatMessageText,
+    // ChatMessageImage,
+    // ChatMessageStealth,
     ChatInput
   },
   beforeRouteUpdate (to, from, next) {
@@ -192,6 +185,9 @@ export default {
     setReply (payloadDigest) {
       console.log('setting reply')
       this.replyDigest = payloadDigest
+    },
+    replyMounted () {
+      this.$refs.chatInput.focusInput()
     }
   },
   computed: {

--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -113,7 +113,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
-import { toMarkdown } from '../utils/markdown'
+import { renderMarkdown } from '../utils/markdown'
 
 import AMessage from '../components/forum/ForumMessage.vue'
 import { errorNotify, infoNotify } from 'src/utils/notifications'
@@ -147,7 +147,7 @@ export default defineComponent({
     }),
     markedMessage () {
       const text: string = this.message
-      return toMarkdown(text)
+      return renderMarkdown(text)
     }
   },
   methods: {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,10 +1,10 @@
 import marked from 'marked'
-const renderer = new marked.Renderer()
-renderer.link = (href, title, text) => {
-  return '<a target="_blank" href="' + href + '">' + text + '</a>'
-}
 import DOMPurify from 'dompurify'
 
-export function toMarkdown (input: string) {
-  return DOMPurify.sanitize(marked(input, { renderer: renderer }), { ADD_ATTR: ['target'] })
+export function renderMarkdown (input: string) {
+  const renderer = new marked.Renderer()
+  renderer.link = (href, title, text) => {
+    return '<a target="_blank" href="' + href + '">' + text + '</a>'
+  }
+  return DOMPurify.sanitize(marked(input, { renderer: renderer }), { ADD_ATTR: ['target'], RETURN_DOM: false })
 }


### PR DESCRIPTION
Many improvements to the Direct Messaging UX

User-facing:
- Chat Bubbles :)
- Message replies nested within Chat Bubbles :)
- Timestamp displays show time passed vs absolute time (e.g. "3 minutes",  "4 hours", "1 day", etc.)
- Timestamp displays are reactive to current time change (currently using Interval; hope to improve functionality later)
- Change "Lotus" to "XPI" for Stamp amounts
- Stealth payments render proper text and colors 

Components:
- ChatMessage.vue no longer loops through message items; message items are gathered and then rendered into a single QChatMessage bubble (will ideally push multiple messages from a single Stack into a single QChatMessage; examples here: https://quasar.dev/vue-components/chat)
- New ChatMessageSuffix.vue component renders timestamp displays and XPI amounts
- Chat.vue and ChatMessage.vue directly render the ChatMessageReply.vue, which loads the Text, Image, and Stealth components as children
- "toMarkdown" function changed to "renderMarkdown" since this makes more sense
- ChatMessage.vue "isLastMessageItem" data property to be used or removed later