### PR TITLE
Remove custom titlebar setup

### DIFF
--- a/src-electron/electron-preload.js
+++ b/src-electron/electron-preload.js
@@ -17,7 +17,6 @@
  */
 
 import { contextBridge, ipcRenderer, shell } from 'electron'
-import { BrowserWindow } from '@electron/remote'
 
 contextBridge.exposeInMainWorld('badge', {
   updateBadge: unread => {
@@ -25,26 +24,6 @@ contextBridge.exposeInMainWorld('badge', {
   },
   setBadgeCount(count) {
     // remote.app.setBadgeCount(unread)
-  },
-})
-
-contextBridge.exposeInMainWorld('myWindowAPI', {
-  minimize() {
-    BrowserWindow.getFocusedWindow().minimize()
-  },
-
-  toggleMaximize() {
-    const win = BrowserWindow.getFocusedWindow()
-
-    if (win.isMaximized()) {
-      win.unmaximize()
-    } else {
-      win.maximize()
-    }
-  },
-
-  close() {
-    BrowserWindow.getFocusedWindow().close()
   },
 })
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,20 +1,5 @@
 <template>
   <q-layout view="hHr LpR lff">
-    <q-header class="electron-only">
-      <q-bar style="height: 23px" class="q-electron-drag q-pr-xs">
-        <q-space />
-        <q-btn dense size="xs" flat icon="minimize" @click="minimize" />
-        <q-btn
-          dense
-          size="xs"
-          flat
-          icon="crop_square"
-          @click="toggleMaximize"
-        />
-        <q-btn dense size="xs" flat icon="close" @click="closeApp" />
-      </q-bar>
-    </q-header>
-
     <q-drawer
       v-model="myDrawerOpen"
       :width="splitterRatio"
@@ -76,21 +61,6 @@ export default {
       getSortedChatOrder: 'chats/getSortedChatOrder',
       getDarkMode: 'appearance/getDarkMode',
     }),
-    minimize() {
-      if (process.env.MODE === 'electron') {
-        window.myWindowAPI.minimize()
-      }
-    },
-    toggleMaximize() {
-      if (process.env.MODE === 'electron') {
-        window.myWindowAPI.toggleMaximize()
-      }
-    },
-    closeApp() {
-      if (process.env.MODE === 'electron') {
-        window.myWindowAPI.close()
-      }
-    },
     tweak(offset, viewportHeight) {
       const height = viewportHeight - offset + 'px'
       return { height, minHeight: height }


### PR DESCRIPTION
The recently added custom titlebar does not properly render on MacOS.
This commit reverts those changes to restore native OS titlebars.
