### PR TITLE
Allow OS to manage notifications

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,5 +1,4 @@
 import { Notify } from 'quasar'
-import { notificationTimeout } from './constants'
 
 // Error notifications
 
@@ -67,9 +66,8 @@ export function desktopNotify(
     body,
     icon,
   })
+
   notify.onclick = () => {
     callback()
-    notify.close()
   }
-  setTimeout(notify.close.bind(notify), notificationTimeout)
 }


### PR DESCRIPTION
Disable notification timeouts and handlers in electron so as to allow
the OS configuration to properly manage notifications.
