### PR TITLE
Make VS Code format settings match prettier expectations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,11 +4,11 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },
-  "javascript.format.insertSpaceBeforeFunctionParenthesis": true,
+  "javascript.format.insertSpaceBeforeFunctionParenthesis": false,
   "javascript.format.insertSpaceAfterConstructor": true,
   "javascript.format.placeOpenBraceOnNewLineForControlBlocks": false,
   "javascript.format.placeOpenBraceOnNewLineForFunctions": false,
-  "typescript.format.insertSpaceBeforeFunctionParenthesis": true,
+  "typescript.format.insertSpaceBeforeFunctionParenthesis": false,
   "typescript.format.placeOpenBraceOnNewLineForControlBlocks": false,
   "typescript.format.placeOpenBraceOnNewLineForFunctions": false,
   "typescript.format.insertSpaceAfterConstructor": true,


### PR DESCRIPTION
Stop VS Code from saving files in a way which will cause the prettier
CI checks to fail.
