### PR TITLE
Improve initial sync speed by only committing received messages in bulk

### DIFF
--- a/src/adapters/vuex-relay-adapter.js
+++ b/src/adapters/vuex-relay-adapter.js
@@ -94,8 +94,8 @@ export async function getRelayClient({
       })
     },
   )
-  client.events.on('receivedMessage', args => {
-    store.dispatch('chats/receiveMessage', args)
+  client.events.on('receivedMessages', messages => {
+    store.dispatch('chats/receiveMessages', messages)
   })
 
   return { client, observables }

--- a/src/cashweb/relay/pAll.ts
+++ b/src/cashweb/relay/pAll.ts
@@ -1,16 +1,17 @@
-export async function pAll<T, FuncType extends () => Promise<T>>(
-  queue: FuncType[],
+export async function pAll<A, R>(
+  queue: A[],
+  func: (arg: A) => Promise<R>,
   concurrency = 5,
 ) {
   let index = 0
-  const results: T[] = []
+  const results: R[] = []
 
   // Run a pseudo-thread
   const execThread = async () => {
     while (index < queue.length) {
       const curIndex = index++
       // Use of `curIndex` is important because `index` may change after await is resolved
-      results[curIndex] = await queue[curIndex]()
+      results[curIndex] = await func(queue[curIndex])
     }
   }
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -115,6 +115,7 @@ export default {
       // const lastReceived = this.lastReceived
       const t0 = performance.now()
       const refreshMessages = () => {
+        this.$q.loading.show({ message: 'Loading messages' })
         // Wait for a connected blockchain client
         if (!this.$indexer.connected) {
           setTimeout(refreshMessages, 100)
@@ -126,6 +127,7 @@ export default {
             const t1 = performance.now()
             console.log(`Loading messages took ${t1 - t0}ms`)
             this.$status.loaded = true
+            this.$q.loading.hide()
           })
           .catch(err => {
             console.error(err)
@@ -168,7 +170,6 @@ export default {
             throw err
           })
       })
-      this.$q.loading.hide()
     },
   },
   computed: {


### PR DESCRIPTION
Currently, the receiving of messages updates the GUI after every message
is received. This really provides a bad experience for the users. This
commit is a pack of changes to bulk load messages initially to avoid
updating the DOM after each message.