### PR TITLE
Don't redownload contacts on route change

### DIFF
--- a/src/pages/AddContact.vue
+++ b/src/pages/AddContact.vue
@@ -1,9 +1,7 @@
 <template>
   <q-card class="q-ma-sm">
     <q-card-section>
-      <div class="text-h6">
-        {{ $t('newContactDialog.newContact') }}
-      </div>
+      <div class="text-h6">{{ $t('newContactDialog.newContact') }}</div>
     </q-card-section>
     <q-card-section>
       <q-input
@@ -114,7 +112,7 @@ export default {
     addContact() {
       const cashAddress = toAPIAddress(this.address) // TODO: Make generic
       this.addContactVuex({ address: cashAddress, contact: this.contact })
-      this.$router.replace(`/chat/${cashAddress}`)
+      this.$router.replace(`/chat/${this.address}`)
     },
     cancel() {
       window.history.length > 1 ? this.$router.go(-1) : this.$router.push('/')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,10 +4,6 @@ import {
   createWebHistory,
   createWebHashHistory,
 } from 'vue-router'
-import { KeyserverHandler } from 'src/cashweb/keyserver'
-import { ReadOnlyRelayClient } from 'src/cashweb/relay'
-import { toAPIAddress } from 'src/utils/address'
-import { keyservers, networkName, displayNetwork } from 'src/utils/constants'
 import type { RouteLocationNormalized, NavigationGuardNext } from 'vue-router'
 import { Store } from 'vuex'
 import { createRoutes } from './routes'
@@ -18,27 +14,7 @@ const protectedRoutes = ['/forum/new-post']
 
 async function addContactFromNavigation<S>(store: Store<S>, address: string) {
   try {
-    // Validate address
-    const apiAddress = toAPIAddress(address) // TODO: Make generic
-    // Pull information from keyserver then relay server
-    const ksHandler = new KeyserverHandler({ keyservers, networkName })
-    const relayURL = await ksHandler.getRelayUrl(apiAddress)
-    if (!relayURL) {
-      return
-    }
-    const relayClient = new ReadOnlyRelayClient(
-      relayURL,
-      networkName,
-      displayNetwork,
-    )
-    const relayData = await relayClient.getRelayData(apiAddress)
-    if (!relayData) {
-      return
-    }
-    store.dispatch('contacts/addContact', {
-      address: apiAddress,
-      contact: { ...relayData, relayURL },
-    })
+    store.dispatch('contacts/addContact', { address })
   } catch (ex) {
     console.error('addContactFromNavigation error:', ex)
   }


### PR DESCRIPTION
Move contact fetching logic to the contacts store so that it can
check to see if a contact already exists. Additionally, don't try to
set the active chat if the contact already exists. This caused
loops due when changing routes quickly in some cases where the
active chat will bounce around between the contacts which were clicked
quickly in the chat list.