### PR TITLE
Refactor message item encoding and decoding to be their own functions

### DIFF
--- a/src/cashweb/relay/decode-entry.ts
+++ b/src/cashweb/relay/decode-entry.ts
@@ -1,0 +1,168 @@
+import assert from 'assert'
+import type { ReplyItem, StealthItem, ImageItem } from '../types/messages'
+import { PayloadEntry } from './relay_pb'
+import { entryToImage } from './images'
+import stealth from './stealth_pb'
+import { TextItem, MessageItem } from '../types/messages'
+import { PublicKey, crypto, Transaction, HDPrivateKey } from 'bitcore-lib-xpi'
+import { Wallet } from '../wallet'
+import { calcUtxoId } from '../wallet/helpers'
+import { Utxo } from '../types/utxo'
+
+export async function decodeEntry(
+  entry: PayloadEntry,
+  outbound: boolean,
+  {
+    networkName,
+    wallet,
+    constructHDStealthPrivateKey,
+  }: {
+    networkName: string
+    wallet: Wallet
+    constructHDStealthPrivateKey: (pubKey: PublicKey) => HDPrivateKey
+  },
+): Promise<[MessageItem, Utxo[]] | null> {
+  // If address data doesn't exist then add it
+  const kind = entry.getKind()
+  const outpoints: Utxo[] = []
+
+  if (kind === 'reply') {
+    const entryData = entry.getBody()
+    const payloadDigest = Buffer.from(entryData).toString('hex')
+    return [
+      {
+        type: 'reply',
+        payloadDigest,
+      } as ReplyItem,
+      outpoints,
+    ]
+  }
+
+  if (kind === 'text-utf8') {
+    const entryData = entry.getBody()
+    if (typeof entryData === 'string') {
+      return [
+        {
+          type: 'text',
+          text: entryData,
+        } as TextItem,
+        outpoints,
+      ]
+    }
+    assert(
+      typeof entryData !== 'string',
+      `text entry data was a string ${entryData}`,
+    )
+    const text = new TextDecoder().decode(entryData)
+    return [
+      {
+        type: 'text',
+        text,
+      } as TextItem,
+      outpoints,
+    ]
+  }
+
+  if (kind === 'stealth-payment') {
+    const entryData = entry.getBody()
+    assert(
+      typeof entryData !== 'string',
+      'entryData should not have string type',
+    )
+    const stealthMessage =
+      stealth.StealthPaymentEntry.deserializeBinary(entryData)
+
+    // Add stealth outputs
+    const outpointsList = stealthMessage.getOutpointsList()
+    const ephemeralPubKeyRaw = stealthMessage.getEphemeralPubKey()
+    const ephemeralPubKey = PublicKey.fromBuffer(
+      Buffer.from(ephemeralPubKeyRaw),
+    )
+    const stealthHDPrivKey = constructHDStealthPrivateKey(ephemeralPubKey)
+
+    let stealthValue = 0
+    for (const [i, outpoint] of outpointsList.entries()) {
+      const stealthTxRaw = Buffer.from(outpoint.getStealthTx())
+      const stealthTx = new Transaction(stealthTxRaw)
+      const txId = stealthTx.txid
+      const vouts = outpoint.getVoutsList()
+
+      if (outbound) {
+        for (const input of stealthTx.inputs) {
+          // Don't add these outputs to our wallet. They're the other persons
+          const utxoId = calcUtxoId({
+            txId: input.prevTxId.toString('hex'),
+            outputIndex: input.outputIndex,
+          })
+          await wallet.deleteUtxo(utxoId)
+        }
+      }
+
+      for (const [j, outputIndex] of vouts.entries()) {
+        const output = stealthTx.outputs[outputIndex]
+        const satoshis = output.satoshis
+
+        const outpointPrivKey = stealthHDPrivKey
+          .deriveChild(44)
+          .deriveChild(145)
+          .deriveChild(i)
+          .deriveChild(j).privateKey
+        const address = output.script.toAddress(networkName) // TODO: Make generic
+        // Network doesn't really matter here, just serves as a placeholder to avoid needing to compute the
+        // HASH160(SHA256(point)) ourself
+        // Also, ensure the point is compressed first before calculating the address so the hash is deterministic
+        const computedAddress = new PublicKey(
+          crypto.Point.pointToCompressed(outpointPrivKey.toPublicKey().point),
+        ).toAddress(networkName)
+        if (
+          !outbound &&
+          !address.toBuffer().equals(computedAddress.toBuffer())
+        ) {
+          console.error('invalid stealth address, ignoring')
+          return null
+        }
+        // total up the satoshis only if we know the txn was valid
+        stealthValue += satoshis
+
+        const stampOutput = {
+          type: 'stealth',
+          address: address.toCashAddress(),
+          satoshis,
+          outputIndex,
+          txId,
+        } as Utxo
+        outpoints.push(stampOutput)
+        if (outbound) {
+          // Don't add these outputs to our wallet. They're the other persons
+        }
+        wallet.putUtxo({
+          ...stampOutput,
+          privKey: Object.freeze(outpointPrivKey),
+        })
+      }
+    }
+    return [
+      {
+        type: 'stealth',
+        amount: stealthValue,
+      } as StealthItem,
+      outpoints,
+    ]
+  }
+
+  if (kind === 'image') {
+    const image = entryToImage(entry)
+
+    // TODO: Save to folder instead of in Vuex
+    return [
+      {
+        type: 'image',
+        image,
+      } as ImageItem,
+      outpoints,
+    ]
+  }
+
+  console.error('Unknown entry Kind', kind)
+  return null
+}

--- a/src/cashweb/relay/encode-entry.ts
+++ b/src/cashweb/relay/encode-entry.ts
@@ -1,0 +1,69 @@
+import assert from 'assert'
+import { PayloadEntry } from './relay_pb'
+import { MessageItem } from '../types/messages'
+import { PublicKey } from 'bitcore-lib-xpi'
+import { Wallet } from '../wallet'
+import { MessageConstructor } from './constructors'
+import { Utxo } from '../types/utxo'
+import { Transaction } from 'bitcore-lib-xpi'
+import { UIOutput } from '../types/user-interface'
+
+export function encodeEntry(
+  item: MessageItem,
+  destinationPublicKey: PublicKey,
+  {
+    wallet,
+    messageConstructor,
+  }: { wallet: Wallet; messageConstructor: MessageConstructor },
+): [PayloadEntry, Transaction[], Utxo[], UIOutput[]] {
+  // TODO: internal type does not match protocol. Consistency is good.
+  if (item.type === 'stealth') {
+    const { paymentEntry, transactionBundle } =
+      messageConstructor.constructStealthEntry({
+        ...item,
+        wallet: wallet,
+        destPubKey: destinationPublicKey,
+      })
+    const transactions: Transaction[] = []
+    const stagedUtxos: Utxo[] = []
+    const outpoints = transactionBundle
+      .map(({ transaction, vouts, usedUtxos }) => {
+        transactions.push(transaction)
+        stagedUtxos.push(...usedUtxos)
+        return vouts.map(
+          vout =>
+            ({
+              type: 'stealth',
+              txId: transaction.txid,
+              satoshis: transaction.outputs[vout].satoshis,
+              outputIndex: vout,
+            } as UIOutput),
+        )
+      })
+      .flat(1)
+    return [paymentEntry, transactions, stagedUtxos, outpoints]
+  }
+  // TODO: internal type does not match protocol. Consistency is good.
+  if (item.type === 'text') {
+    return [messageConstructor.constructTextEntry({ ...item }), [], [], []]
+  }
+  if (item.type === 'forward') {
+    return [messageConstructor.constructForwardEntry({ ...item }), [], [], []]
+  }
+  if (item.type === 'reply') {
+    return [messageConstructor.constructReplyEntry({ ...item }), [], [], []]
+  }
+  if (item.type === 'image') {
+    return [messageConstructor.constructImageEntry({ ...item }), [], [], []]
+  }
+  if (item.type === 'p2pkh') {
+    const { entry, transaction, usedUtxos } =
+      messageConstructor.constructP2PKHEntry({
+        ...item,
+        wallet: wallet,
+      })
+
+    return [entry, [transaction], usedUtxos, []]
+  }
+  assert(false, 'Unknown entry type')
+}

--- a/src/cashweb/types/user-interface.ts
+++ b/src/cashweb/types/user-interface.ts
@@ -1,0 +1,40 @@
+import { PublicKey } from 'bitcore-lib-xpi'
+import { MessageItem } from './messages'
+import { Utxo } from './utxo'
+
+export interface UIStealthOutput {
+  type: 'stealth'
+  txId: string
+  satoshis: number
+  outputIndex: number
+}
+
+export interface UIStampOutput {
+  type: 'stamp'
+  txId: string
+  satoshis: number
+  outputIndex: number
+}
+
+export type UIOutput = UIStealthOutput | UIStampOutput
+
+export type ReceivedMessage = {
+  outbound: boolean
+  status: string
+  items: MessageItem[]
+  serverTime: number
+  receivedTime: number
+  outpoints: Utxo[]
+  senderAddress: string
+  destinationAddress: string
+}
+
+export type ReceivedMessageWrapper = {
+  outbound: boolean
+  senderAddress: string
+  copartyAddress: string
+  copartyPubKey: PublicKey
+  index: string
+  stampValue: number
+  message: Readonly<ReceivedMessage>
+}

--- a/src/store/modules/chats.ts
+++ b/src/store/modules/chats.ts
@@ -8,14 +8,14 @@ import { store } from '../../adapters/level-message-store'
 import { toDisplayAddress } from '../../utils/address'
 import { formatBalance } from '../../utils/formatting'
 import { Utxo } from 'src/cashweb/types/utxo'
-import {
+import type {
   Message,
   MessageItem,
   TextItem,
   ImageItem,
   StealthItem,
 } from 'src/cashweb/types/messages'
-import { ReceivedMessageWrapper } from 'src/cashweb/relay'
+import type { ReceivedMessageWrapper } from 'src/cashweb/types/user-interface'
 
 type ChatMessage = {
   outbound: boolean
@@ -253,6 +253,14 @@ const module: Module<State, unknown> = {
         console.error(displayAddress)
         return null
       }
+      if (lastItem.type === 'forward') {
+        const info = {
+          outbound: lastMessage.outbound,
+          text: 'Forwarded from ' + lastItem.from,
+        }
+        return info
+      }
+
       if (lastItem.type === 'text') {
         const info = {
           outbound: lastMessage.outbound,


### PR DESCRIPTION
In order to implement message forwarding, we need to be able to
recursively encode message entries. This requires the functions for
encoding and decoding entries, to be have their own names so they can be
recursively called. This commit refactors those portions of the relay
client to be their own functions to enable this future functionality.
