### PR TITLE
Fix iOS loading by using callbacks with `Notification.requestPermission`

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -87,9 +87,22 @@ export default {
       this.myDrawerOpen = !this.myDrawerOpen
     },
     promptNotificationPermission() {
-      window.Notification.requestPermission().then(
-        () => (this.notificationPermission = window.Notification.permission),
-      )
+      try {
+        Notification.requestPermission().then(
+          () => (this.notificationPermission = window.Notification.permission),
+        )
+      } catch (error) {
+        // Safari doesn't return a promise for requestPermissions and it
+        // throws a TypeError. It takes a callback as the first argument
+        // instead.
+        if (error instanceof TypeError) {
+          Notification.requestPermission(() => {
+            this.notificationPermission = window.Notification.permission
+          })
+        } else {
+          throw error
+        }
+      }
     },
     shortcutKeyListener(e) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {


### PR DESCRIPTION
Safari for iOS does not support the new promise version of
`Notification.requestPermission`. This code catches the undefined error
that results on Safari iOS and uses the callback based version of
requestPermission in that case.