### PR TITLE
contactStore fixes

### DIFF
--- a/src/boot/setup-apis.ts
+++ b/src/boot/setup-apis.ts
@@ -142,7 +142,7 @@ export default boot(async ({ app }) => {
   if (token) {
     relayClient.setToken(token)
   }
-  
+
   const contactStore = useContactStore()
   await contactStore.restored
 

--- a/src/boot/setup-apis.ts
+++ b/src/boot/setup-apis.ts
@@ -12,6 +12,7 @@ import { ChronikClient, WsEndpoint } from 'chronik-client'
 import { useWalletStore } from 'src/stores/wallet'
 import { useProfileStore } from 'src/stores/my-profile'
 import { useRelayClientStore } from 'src/stores/relay-client'
+import { useContactStore } from 'src/stores/contacts'
 
 function instrumentIndexerClient({
   chronikWs,
@@ -141,6 +142,9 @@ export default boot(async ({ app }) => {
   if (token) {
     relayClient.setToken(token)
   }
+  
+  const contactStore = useContactStore()
+  await contactStore.restored
 
   app.config.globalProperties.$wallet = wallet
   app.config.globalProperties.$indexer = indexerObservables

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -86,7 +86,7 @@ export function rehydrateContacts(contactState?: RestorableState): State {
             profile: {
               ...profile,
               pubKey: profile?.pubKey
-                ? markRaw(PublicKey.fromBuffer(profile?.pubKey))
+                ? markRaw(PublicKey.fromBuffer(new Uint8Array(Object.values(profile?.pubKey))))
                 : null,
             },
           }

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -86,11 +86,7 @@ export function rehydrateContacts(contactState?: RestorableState): State {
             profile: {
               ...profile,
               pubKey: profile?.pubKey
-                ? markRaw(
-                    PublicKey.fromBuffer(
-                      new Uint8Array(Object.values(profile?.pubKey)),
-                    ),
-                  )
+                ? markRaw(PublicKey.fromBuffer(profile.pubKey))
                 : null,
             },
           }
@@ -399,7 +395,19 @@ export const useContactStore = defineStore('contacts', {
           }
         }, state.contacts),
       }
-      storage.put('contacts', JSON.stringify(reducedState))
+      storage.put(
+        'contacts',
+        JSON.stringify(reducedState, (k, v) => {
+          switch (k) {
+            // Convert the pubKey Uint8Array into a binary string for storage
+            case 'pubKey': {
+              // only buffer if pubKey defined
+              return v ? Buffer.from(v).toString('binary') : v
+            }
+          }
+          return v
+        }),
+      )
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async restore(storage, metadata): Promise<Partial<State>> {
@@ -416,7 +424,20 @@ export const useContactStore = defineStore('contacts', {
         return { ...defaultContactsState }
       }
 
-      const deserializedProfile = JSON.parse(contacts) as RestorableState
+      const deserializedProfile = JSON.parse(contacts, (k, v) => {
+        switch (k) {
+          // Restore pubKey binary string to Uint8Array
+          case 'pubKey': {
+            // pubKey will be an object if not processed via JSON.stringify replacer function
+            const buf =
+              typeof v != 'string'
+                ? Object.values(v as object)
+                : Buffer.from(v, 'binary')
+            return new Uint8Array(buf)
+          }
+        }
+        return v
+      }) as RestorableState
       const rehydratedContacts = await rehydrateContacts(deserializedProfile)
       return rehydratedContacts
     },

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -68,7 +68,9 @@ export type RestorableState = {
   updateInterval: number
 }
 
-export function rehydrateContacts(contactState?: RestorableState): State {
+export async function rehydrateContacts(
+  contactState?: RestorableState,
+): Promise<State> {
   if (!contactState) {
     return defaultContactsState
   }

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -86,7 +86,11 @@ export function rehydrateContacts(contactState?: RestorableState): State {
             profile: {
               ...profile,
               pubKey: profile?.pubKey
-                ? markRaw(PublicKey.fromBuffer(new Uint8Array(Object.values(profile?.pubKey))))
+                ? markRaw(
+                    PublicKey.fromBuffer(
+                      new Uint8Array(Object.values(profile?.pubKey)),
+                    ),
+                  )
                 : null,
             },
           }


### PR DESCRIPTION
1. `ce3c4cf`: Work around a bug in which the `profile.pubKey` Uint8Array is incorrectly saved/restored as an object
2. `8d7f75d`: Ensure the contact store is loaded at boot in the setup-apis
3. `cf6a2d6`: Accomplishes the same as `ce3c4cf`, except it saves the `profile.pubKey` as a binary string using `JSON.stringify` replacer function. The binary string is restored as a Uint8Array in the `JSON.parse` reviver function, which is then passed to the `rehydrateContacts()` and properly converted back into a `PublicKey`