### PR TITLE
Ensure seed is saved permanently and not regenerated before setup

### DIFF
--- a/src/components/setup/AccountStep.vue
+++ b/src/components/setup/AccountStep.vue
@@ -110,7 +110,6 @@ export default {
       this.$nextTick(() => this.$refs.seedInput.select())
     },
     newCharacter() {
-      this.generateMnemonic()
       this.action = 'new'
       this.rawName = ''
     },

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -124,6 +124,9 @@ export default defineComponent({
     const appearance = useAppearanceStore()
     const myProfile = useProfileStore()
     const contacts = useContactStore()
+    if (!wallet.seedPhrase) {
+      wallet.setSeedPhrase(generateMnemonic())
+    }
 
     return {
       setRelayToken: relayClient.setToken,
@@ -148,7 +151,7 @@ export default defineComponent({
       accountData: {
         name: '',
         valid: false,
-        seed: wallet.seedPhrase || generateMnemonic(),
+        seed: wallet.seedPhrase,
       },
       relayData: defaultRelayData,
       relayUrl: defaultRelayUrl,
@@ -211,6 +214,10 @@ export default defineComponent({
             reject(err)
           }
         }
+        assert(
+          this.accountData.seed,
+          'Missing seed phrase? State ordering issue?',
+        )
         this.seed = this.accountData.seed
         this.setSeedPhrase(this.seed)
         worker.postMessage(this.seed)

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -26,7 +26,10 @@ export type RestorableState = Omit<State, 'xPrivKey'> & { xPrivKey: unknown }
 
 export async function rehydrateWallet(wallet: RestorableState): Promise<State> {
   if (!wallet || !wallet.xPrivKey) {
-    return defaultWalletState
+    return {
+      ...defaultWalletState,
+      seedPhrase: wallet.seedPhrase,
+    }
   }
   let balance = 0
   const utxos: Record<string, number> = {}
@@ -99,8 +102,8 @@ export const useWalletStore = defineStore('wallet', {
         //
       }
       const deserializedWallet = JSON.parse(wallet) as RestorableState
-      const rehydratedChat = await rehydrateWallet(deserializedWallet)
-      return rehydratedChat
+      const rehydratedWallet = await rehydrateWallet(deserializedWallet)
+      return rehydratedWallet
     },
   },
 })


### PR DESCRIPTION
Currently, users are losing funds due to clicking back after funding
their first wallet. This is because the seed regenerates and isn't
saved in the store.

This commit ensures the seed is generated on Setup load only if it does
not exist. Seeds on the "new character" page are also not regenerated on
load. And the wallet restore function now maintains the seed even when
the xpubkey is not yet generated.