### PR TITLE
Ensure balance resets when wallet is reset

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -59,6 +59,7 @@ export const useWalletStore = defineStore('wallet', {
     reset() {
       this.xPrivKey = null
       this.utxos = {}
+      this.balance = 0
     },
     setXPrivKey(xPrivKey: HDPrivateKey) {
       this.xPrivKey = markRaw(xPrivKey)


### PR DESCRIPTION
During setup, navigating back and forth can cause the balance to keep
incrementing due to it rescanning, dropping the UTXOs, but not resetting
the balance.