### PR TITLE
Fix adding new contacts and various pubkey handling associated

### DIFF
--- a/src/components/dialogs/ContactBookDialog.vue
+++ b/src/components/dialogs/ContactBookDialog.vue
@@ -40,10 +40,12 @@
 </template>
 
 <script lang="ts">
-import ContactList from '../contacts/ContactList.vue'
 import { defineComponent } from 'vue'
-import { ContactState, useContactStore } from 'src/stores/contacts'
 import { QInput } from 'quasar'
+import { storeToRefs } from 'pinia'
+
+import ContactList from '../contacts/ContactList.vue'
+import { ContactState, useContactStore } from 'src/stores/contacts'
 
 export default defineComponent({
   props: {
@@ -54,8 +56,9 @@ export default defineComponent({
   },
   setup() {
     const contactStore = useContactStore()
+    const { getContacts } = storeToRefs(contactStore)
     return {
-      contacts: contactStore.getContacts,
+      contacts: getContacts,
     }
   },
   components: {

--- a/src/stores/chats.ts
+++ b/src/stores/chats.ts
@@ -349,6 +349,7 @@ export const useChatStore = defineStore('chats', {
           address: displayAddress,
         }
       }
+      this.activeChatAddr = displayAddress
     },
     sendMessageLocal({
       address,

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -294,7 +294,7 @@ export const useContactStore = defineStore('contacts', {
             relayURL,
             profile: {
               ...relayData.profile,
-              pubKey: PublicKey.fromBuffer(relayData.profile.pubKey),
+              pubKey: markRaw(PublicKey.fromBuffer(relayData.profile.pubKey)),
             },
           },
         })


### PR DESCRIPTION
This commit fixes several issues around adding new contacts that didn't
seem to cause issues when using Vuex (although it should have). There
are several issues fixed: Handling undefined values in AddContact.vue,
marking contact PubKey's raw everywhere relevant, and also ensuring
that the chat is created when a new contact is added. The chat list side
bar requires a chat to be created, in addition to the contact being
added.