### PR TITLE
Update Forum time-based filtering

### DIFF
--- a/src/components/forum/ForumMessage.vue
+++ b/src/components/forum/ForumMessage.vue
@@ -10,9 +10,9 @@
         <q-card-section class="q-pa-none text-center">
           <q-btn flat icon="arrow_drop_up" padding="0" @click="addVotes(10)" />
         </q-card-section>
-        <q-card-section class="q-pa-none q-mt-xs text-center">{{
-          formatSatoshis(message.satoshis)
-        }}</q-card-section>
+        <q-card-section class="q-pa-none q-mt-xs text-center">
+          {{ formatSatoshis(message.satoshis) }}
+        </q-card-section>
         <q-card-section class="q-pa-none q-mt-xs text-center">
           <q-btn
             flat
@@ -41,9 +41,9 @@
               class="text-h6 text-bold q-mr-md post-title"
               >{{ entry.title || 'Untitled' }}</a
             >
-            <span v-if="!entry.url" class="text-h6 text-bold q-mr-md">
-              {{ entry.title || 'Untitled' }}
-            </span>
+            <span v-if="!entry.url" class="text-h6 text-bold q-mr-md">{{
+              entry.title || 'Untitled'
+            }}</span>
             <div class="q-mt-xs">
               <q-btn
                 rounded
@@ -112,11 +112,13 @@
 </template>
 
 <script lang="ts">
-import { renderMarkdown } from '../../utils/markdown'
 import moment from 'moment'
-
 import { defineComponent } from 'vue'
 import type { PropType } from 'vue'
+import { storeToRefs } from 'pinia'
+
+import { renderMarkdown } from '../../utils/markdown'
+
 import AMessageReplies from './ForumMessageReplies.vue'
 
 import { ForumMessage } from '../../cashweb/types/forum'
@@ -127,15 +129,15 @@ export default defineComponent({
   setup() {
     const forumStore = useForumStore()
     const contactStore = useContactStore()
+    const { messages, topics, selectedTopic } = storeToRefs(forumStore)
 
     return {
-      getMessages: forumStore.getMessages,
+      storeMessages: messages,
       getMessage: forumStore.getMessage,
-      topics: forumStore.getTopics,
+      topics,
       getContactProfile: contactStore.getContactProfile,
       haveContact: contactStore.haveContact,
-      getSelectedTopic: forumStore.getSelectedTopic,
-
+      selectedTopic,
       addOffering: forumStore.addOffering,
     }
   },
@@ -245,7 +247,7 @@ export default defineComponent({
       return this.getMessage(this.parentDigest)
     },
     messages() {
-      return this.getMessages.filter((message: ForumMessage) =>
+      return this.storeMessages.filter((message: ForumMessage) =>
         message.entries.some(entry => entry.kind === 'post'),
       )
     },

--- a/src/components/panels/ForumDrawer.vue
+++ b/src/components/panels/ForumDrawer.vue
@@ -82,20 +82,20 @@ export default defineComponent({
   setup() {
     const forum = useForumStore()
     const {
-      getTopics,
-      getSelectedTopic,
-      getSortMode,
-      getDuration,
-      getVoteThreshold,
-      getCompactView,
+      topics,
+      selectedTopic,
+      sortMode,
+      duration,
+      voteThreshold,
+      compactView,
     } = storeToRefs(forum)
     return {
-      topics: getTopics,
-      getSelectedTopic,
-      getSortMode,
-      getDuration,
-      getVoteThreshold,
-      getCompactView,
+      topics,
+      storeSelectedTopic: selectedTopic,
+      storeSortMode: sortMode,
+      storeDuration: duration,
+      storeVoteThreshold: voteThreshold,
+      storeCompactView: compactView,
       refreshMessages: forum.refreshMessages,
       setSelectedTopic: forum.setSelectedTopic,
       setSortMode: forum.setSortMode,
@@ -130,7 +130,7 @@ export default defineComponent({
         this.setSortMode(newVal as SortMode)
       },
       get(): string {
-        return this.getSortMode
+        return this.storeSortMode
       },
     },
     selectedTopic: {
@@ -138,17 +138,16 @@ export default defineComponent({
         this.setSelectedTopic(newVal ?? '')
       },
       get(): string {
-        return this.getSelectedTopic
+        return this.storeSelectedTopic
       },
     },
     duration: {
       set(newVal?: { label: string; value: number }) {
-        console.log(newVal)
         this.setDuration(newVal?.value ?? 0)
         this.refreshContent()
       },
       get(): { label: string; value: number } | undefined {
-        return DURATIONS.find(duration => duration.value === this.getDuration)
+        return DURATIONS.find(duration => duration.value === this.storeDuration)
       },
     },
     compactView: {
@@ -156,7 +155,7 @@ export default defineComponent({
         this.setCompactView(newVal ?? false)
       },
       get(): boolean {
-        return this.getCompactView
+        return this.storeCompactView
       },
     },
     threshold: {
@@ -166,7 +165,7 @@ export default defineComponent({
         this.setVoteThreshold(newThreshold)
       },
       get(): string {
-        return this.getVoteThreshold.toString()
+        return this.storeVoteThreshold.toString()
       },
     },
   },

--- a/src/layouts/ForumLayout.vue
+++ b/src/layouts/ForumLayout.vue
@@ -50,6 +50,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { storeToRefs } from 'pinia'
 
 import { useForumStore } from 'src/stores/forum'
 
@@ -63,12 +64,13 @@ export default defineComponent({
   },
   setup() {
     const forumStore = useForumStore()
+    const { topics, selectedTopic } = storeToRefs(forumStore)
 
     return {
       refreshMessages: forumStore.refreshMessages,
       setSelectedTopic: forumStore.setSelectedTopic,
-      topics: forumStore.getTopics,
-      getSelectedTopic: forumStore.getSelectedTopic,
+      topics,
+      storeSelectedTopic: selectedTopic,
     }
   },
   components: { ForumDrawer },
@@ -98,7 +100,7 @@ export default defineComponent({
         }
       },
       get(): string {
-        return this.getSelectedTopic
+        return this.storeSelectedTopic
       },
     },
   },

--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -77,6 +77,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { storeToRefs } from 'pinia'
 
 import { renderMarkdown } from '../utils/markdown'
 import { useForumStore } from 'src/stores/forum'
@@ -87,9 +88,10 @@ import { errorNotify, infoNotify } from 'src/utils/notifications'
 export default defineComponent({
   setup() {
     const forum = useForumStore()
+    const { topics, getMessage } = storeToRefs(forum)
     return {
-      getMessage: forum.getMessage,
-      availableTopics: forum.getTopics,
+      getMessage: getMessage,
+      availableTopics: topics,
       pushNewTopic: forum.pushNewTopic,
       postMessage: forum.putMessage,
     }

--- a/src/stores/forum.ts
+++ b/src/stores/forum.ts
@@ -37,15 +37,6 @@ export const useForumStore = defineStore('forum', {
     compactView: false,
   }),
   getters: {
-    getMessages(state) {
-      return state.messages
-    },
-    getTopics(state) {
-      return state.topics
-    },
-    getSelectedTopic(state) {
-      return state.selectedTopic
-    },
     getMessage(state) {
       return (messageDigest?: string) => {
         console.log('messageDigest', messageDigest)
@@ -54,25 +45,6 @@ export const useForumStore = defineStore('forum', {
         }
         return state.index[messageDigest]
       }
-    },
-    lastMessageTime(state) {
-      return state.messages.reduce(
-        (maxDate, message) =>
-          !maxDate || maxDate < message.timestamp ? message.timestamp : maxDate,
-        undefined as Date | undefined,
-      )
-    },
-    getSortMode(state) {
-      return state.sortMode
-    },
-    getDuration(state) {
-      return state.duration
-    },
-    getVoteThreshold(state) {
-      return state.voteThreshold
-    },
-    getCompactView(state) {
-      return state.compactView
     },
   },
   actions: {
@@ -161,7 +133,7 @@ export const useForumStore = defineStore('forum', {
         keyservers,
       })
       console.log('fetching messages')
-      const from = Date.now() - this.getDuration
+      const from = Date.now() - this.duration
       console.log(from)
       const entries = await keyserver.getBroadcastMessages('', from)
       if (!entries) {

--- a/src/utils/sorting.ts
+++ b/src/utils/sorting.ts
@@ -24,7 +24,7 @@ export function halfLifeSort(posts: ForumMessage[]) {
 export function timeSort(posts: ForumMessage[]) {
   return posts
     .slice()
-    .sort((a, b) => b.timestamp.valueOf() - a.timestamp.valueOf())
+    .sort((a, b) => a.timestamp.valueOf() - b.timestamp.valueOf())
 }
 
 export function voteSort(posts: ForumMessage[]) {


### PR DESCRIPTION
Currently, the posts were not being filtered by the selected duration.
This commit should make only recent messages show up in the Forum main
view.

Closes  #574