### PR TITLE
Fix stealth transaction sends

### DIFF
--- a/src/cashweb/relay/decode-entry.ts
+++ b/src/cashweb/relay/decode-entry.ts
@@ -134,6 +134,7 @@ export async function decodeEntry(
         outpoints.push(stampOutput)
         if (outbound) {
           // Don't add these outputs to our wallet. They're the other persons
+          continue
         }
         wallet.putUtxo({
           ...stampOutput,


### PR DESCRIPTION
During receipt of a stealth lotus send, the relay client was incorrectly
adding the stealth outgoing utxos to the local wallet. This would bust
sends by attempting to include those UTXOs in the inputs of a new
transaction. This commit adds back the missing "continue" which short
circuits the wallet add for outbound transactions.
