### PR TITLE
Remove nested QLayouts

### DIFF
--- a/src/layouts/ChatLayout.vue
+++ b/src/layouts/ChatLayout.vue
@@ -1,9 +1,5 @@
 <template>
-  <q-layout
-    view="lhh LpR lff"
-    container
-    class="hide-scrollbar absolute full-width"
-  >
+  <div>
     <q-drawer v-model="contactDrawerOpen" side="right" :breakpoint="800">
       <right-drawer
         v-if="address"
@@ -47,15 +43,11 @@
       </q-toolbar>
     </q-header>
 
-    <q-page-container>
-      <q-page class="q-pt-xs">
-        <router-view
-          @sendFileClicked="toSendFileDialog"
-          @giveLotusClicked="sendMoneyOpen = true"
-        />
-      </q-page>
-    </q-page-container>
-  </q-layout>
+    <router-view
+      @sendFileClicked="toSendFileDialog"
+      @giveLotusClicked="sendMoneyOpen = true"
+    />
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/layouts/ForumLayout.vue
+++ b/src/layouts/ForumLayout.vue
@@ -1,9 +1,5 @@
 <template>
-  <q-layout
-    view="lhh LpR lff"
-    container
-    class="hide-scrollbar absolute full-width"
-  >
+  <div>
     <q-drawer v-model="showForumDrawer" side="right" :breakpoint="800">
       <forum-drawer />
     </q-drawer>
@@ -45,7 +41,7 @@
         </q-scroll-area>
       </q-page>
     </q-page-container>
-  </q-layout>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-layout view="hHr LpR lff">
+  <q-layout view="lHr lpr lFr">
     <q-btn
       v-show="false"
       @click="promptNotificationPermission"
@@ -16,15 +16,11 @@
     <q-dialog v-model="contactBookOpen">
       <contact-book-dialog :contact-click="contactClicked" />
     </q-dialog>
-    <q-page-container>
-      <q-page :style-fn="tweak">
-        <router-view
-          @toggleContactDrawerOpen="toggleContactDrawerOpen"
-          @toggleMyDrawerOpen="toggleMyDrawerOpen"
-          @setupCompleted="setupConnections"
-        />
-      </q-page>
-    </q-page-container>
+    <router-view
+      @toggleContactDrawerOpen="toggleContactDrawerOpen"
+      @toggleMyDrawerOpen="toggleMyDrawerOpen"
+      @setupCompleted="setupConnections"
+    />
   </q-layout>
 </template>
 
@@ -113,10 +109,6 @@ export default defineComponent({
     }
   },
   methods: {
-    tweak(offset: number, viewportHeight: number) {
-      const height = viewportHeight - offset + 'px'
-      return { height, minHeight: height }
-    },
     toggleContactDrawerOpen() {
       console.log('toggleContactDrawerOpen')
       this.contactDrawerOpen = !this.contactDrawerOpen

--- a/src/layouts/SetupLayout.vue
+++ b/src/layouts/SetupLayout.vue
@@ -1,11 +1,8 @@
 <template>
-  <q-layout view="hHh Lpr fFf">
-    <q-page-container>
-      <router-view :is-basic="isBasic" />
-    </q-page-container>
-
+  <div>
+    <router-view :is-basic="isBasic" />
     <status-footer v-model="isBasic" />
-  </q-layout>
+  </div>
 </template>
 
 <script>

--- a/src/layouts/TopicLayout.vue
+++ b/src/layouts/TopicLayout.vue
@@ -1,9 +1,5 @@
 <template>
-  <q-layout
-    view="lhh LpR lff"
-    container
-    class="hide-scrollbar absolute full-width"
-  >
+  <div>
     <q-drawer v-model="showTopicDrawer" side="right" :breakpoint="800">
       <topic-drawer :topic="topic" />
     </q-drawer>
@@ -38,7 +34,7 @@
     <q-footer bordered v-if="$status.setup">
       <topic-input @send-message="sendMessage" v-model:message="message" />
     </q-footer>
-  </q-layout>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/pages/AddContact.vue
+++ b/src/pages/AddContact.vue
@@ -1,72 +1,78 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-card-section>
-      <div class="text-h6">{{ $t('newContactDialog.newContact') }}</div>
-    </q-card-section>
-    <q-card-section>
-      <q-input
-        class="text-bold text-h6"
-        v-model="address"
-        filled
-        dense
-        :placeholder="$t('newContactDialog.enterBitcoinCashAddress')"
-        ref="address"
-        @keydown.enter.prevent="addContact()"
-      />
-    </q-card-section>
-    <q-slide-transition>
-      <q-card-section
-        class="q-py-none"
-        v-if="contact === null && address !== ''"
-      >
-        <q-item>
-          <q-item-section avatar>
-            <q-icon color="negative" name="error" size="xl" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ $t('newContactDialog.notFound') }}</q-item-label>
-            <!-- TODO: Error information here -->
-          </q-item-section>
-        </q-item>
-      </q-card-section>
-      <q-card-section class="q-py-none" v-else-if="loading">
-        <q-item>
-          <q-item-section avatar>
-            <q-skeleton type="QAvatar" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>
-              <q-skeleton type="text" />
-            </q-item-label>
-            <q-item-label caption>
-              <q-skeleton type="text" />
-            </q-item-label>
-          </q-item-section>
-        </q-item>
-      </q-card-section>
-      <q-card-section v-else-if="contact" class="q-py-none">
-        <q-item>
-          <q-item-section avatar v-if="contact?.profile?.avatar">
-            <q-avatar rounded>
-              <img :src="contact?.profile?.avatar" size="xl" />
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ contact?.profile?.name }}</q-item-label>
-          </q-item-section>
-        </q-item>
-      </q-card-section>
-    </q-slide-transition>
-    <q-card-actions align="right">
-      <q-btn label="Cancel" color="negative" @click="cancel" />
-      <q-btn
-        :disable="contact === null"
-        label="Add"
-        color="primary"
-        @click="addContact()"
-      />
-    </q-card-actions>
-  </q-card>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">{{ $t('newContactDialog.newContact') }}</div>
+        </q-card-section>
+        <q-card-section>
+          <q-input
+            class="text-bold text-h6"
+            v-model="address"
+            filled
+            dense
+            :placeholder="$t('newContactDialog.enterBitcoinCashAddress')"
+            ref="address"
+            @keydown.enter.prevent="addContact()"
+          />
+        </q-card-section>
+        <q-slide-transition>
+          <q-card-section
+            class="q-py-none"
+            v-if="contact === null && address !== ''"
+          >
+            <q-item>
+              <q-item-section avatar>
+                <q-icon color="negative" name="error" size="xl" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{
+                  $t('newContactDialog.notFound')
+                }}</q-item-label>
+                <!-- TODO: Error information here -->
+              </q-item-section>
+            </q-item>
+          </q-card-section>
+          <q-card-section class="q-py-none" v-else-if="loading">
+            <q-item>
+              <q-item-section avatar>
+                <q-skeleton type="QAvatar" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>
+                  <q-skeleton type="text" />
+                </q-item-label>
+                <q-item-label caption>
+                  <q-skeleton type="text" />
+                </q-item-label>
+              </q-item-section>
+            </q-item>
+          </q-card-section>
+          <q-card-section v-else-if="contact" class="q-py-none">
+            <q-item>
+              <q-item-section avatar v-if="contact?.profile?.avatar">
+                <q-avatar rounded>
+                  <img :src="contact?.profile?.avatar" size="xl" />
+                </q-avatar>
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ contact?.profile?.name }}</q-item-label>
+              </q-item-section>
+            </q-item>
+          </q-card-section>
+        </q-slide-transition>
+        <q-card-actions align="right">
+          <q-btn label="Cancel" color="negative" @click="cancel" />
+          <q-btn
+            :disable="contact === null"
+            label="Add"
+            color="primary"
+            @click="addContact()"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">

--- a/src/pages/AddTopic.vue
+++ b/src/pages/AddTopic.vue
@@ -1,37 +1,41 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-card-section>
-      <div class="text-h6">{{ $t('newTopicDialog.newTopic') }}</div>
-    </q-card-section>
-    <q-card-section>
-      <q-input
-        class="text-bold text-h6"
-        valid
-        v-model="topic"
-        filled
-        dense
-        reactive-rules
-        :rules="[
-          val => val.length > 3 || 'Please use minimum of 3 characters',
-          val =>
-            /^[a-zA-Z0-9.]+$/.test(val) ||
-            'A-Z, a-z, 0-9, and periods are the only valid characters',
-        ]"
-        :placeholder="$t('newTopicDialog.enterTopic')"
-        ref="topicInput"
-        @keydown.enter.prevent="addTopic()"
-      />
-    </q-card-section>
-    <q-card-actions align="right">
-      <q-btn label="Cancel" color="negative" @click="cancel" />
-      <q-btn
-        :disable="topic === ''"
-        label="Add"
-        color="primary"
-        @click="addTopic()"
-      />
-    </q-card-actions>
-  </q-card>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">{{ $t('newTopicDialog.newTopic') }}</div>
+        </q-card-section>
+        <q-card-section>
+          <q-input
+            class="text-bold text-h6"
+            valid
+            v-model="topic"
+            filled
+            dense
+            reactive-rules
+            :rules="[
+              val => val.length > 3 || 'Please use minimum of 3 characters',
+              val =>
+                /^[a-zA-Z0-9.]+$/.test(val) ||
+                'A-Z, a-z, 0-9, and periods are the only valid characters',
+            ]"
+            :placeholder="$t('newTopicDialog.enterTopic')"
+            ref="topicInput"
+            @keydown.enter.prevent="addTopic()"
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn label="Cancel" color="negative" @click="cancel" />
+          <q-btn
+            :disable="topic === ''"
+            label="Add"
+            color="primary"
+            @click="addTopic()"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">

--- a/src/pages/Changelog.vue
+++ b/src/pages/Changelog.vue
@@ -1,9 +1,5 @@
 <template>
-  <q-layout
-    view="lhh LpR lff"
-    container
-    class="hide-scrollbar absolute full-width"
-  >
+  <div>
     <q-header>
       <q-toolbar class="q-pl-sm">
         <q-btn
@@ -13,12 +9,12 @@
           @click="toggleSettingsDrawerOpen"
           icon="menu"
         />
-        <q-toolbar-title class="h6"> Changelog </q-toolbar-title>
+        <q-toolbar-title class="h6">Changelog</q-toolbar-title>
       </q-toolbar>
     </q-header>
 
     <q-page-container>
-      <q-page>
+      <q-page class="q-ma-none q-pa-sm">
         <q-scroll-area
           ref="chatScroll"
           @scroll="scrollHandler"
@@ -281,7 +277,7 @@
         </q-page-sticky>
       </q-page>
     </q-page-container>
-  </q-layout>
+  </div>
 </template>
 
 <script>

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -1,75 +1,85 @@
 <template>
-  <q-scroll-area
-    ref="chatScroll"
-    @scroll="scrollHandler"
-    class="q-px-none absolute full-width full-height column"
-  >
-    <div class="row q-px-lg">
-      <template
-        v-for="(msg, index) in chunkedMessages"
-        :key="msg.payloadDigest"
-      >
-        <chat-message
-          :index="index"
-          :message="msg"
-          :address="address"
-          :name="getContact(msg.outbound).name"
-          :chat-width="chatWidth"
-          :payload-digest="msg.payloadDigest"
-          :ref="msg.payloadDigest"
-          @replyClicked="
-            ({ address, payloadDigest }) => setReply(payloadDigest)
-          "
-          @replyDivClick="scrollToMessage"
-        />
-      </template>
-    </div>
-  </q-scroll-area>
-  <q-page-sticky position="bottom-right" :offset="[18, 18]" v-show="!bottom">
-    <q-btn
-      round
-      size="md"
-      icon="arrow_downward"
-      @mousedown.prevent="buttonScrollBottom"
-      color="accent"
-    />
-  </q-page-sticky>
-  <q-inner-loading
-    :dark="$q.dark.isActive"
-    :showing="!!scrollDigest"
-    size="md"
-    label="Loading more messages..."
-  />
-  <q-footer bordered>
-    <div v-if="!!replyDigest" class="q-px-md q-pt-sm" ref="replyBox">
-      <!-- Reply box -->
-      <div class="row justify-end">
-        <div class="col-auto">
+  <div>
+    <q-page-container>
+      <q-page>
+        <q-scroll-area
+          ref="chatScroll"
+          @scroll="scrollHandler"
+          class="q-px-none absolute full-width full-height column"
+        >
+          <div class="row q-px-lg">
+            <template
+              v-for="(msg, index) in chunkedMessages"
+              :key="msg.payloadDigest"
+            >
+              <chat-message
+                :index="index"
+                :message="msg"
+                :address="address"
+                :name="getContact(msg.outbound).name"
+                :chat-width="chatWidth"
+                :payload-digest="msg.payloadDigest"
+                :ref="msg.payloadDigest"
+                @replyClicked="
+                  ({ address, payloadDigest }) => setReply(payloadDigest)
+                "
+                @replyDivClick="scrollToMessage"
+              />
+            </template>
+          </div>
+        </q-scroll-area>
+        <q-page-sticky
+          position="bottom-right"
+          :offset="[18, 18]"
+          v-show="!bottom"
+        >
           <q-btn
-            dense
-            flat
+            round
+            size="md"
+            icon="arrow_downward"
+            @mousedown.prevent="buttonScrollBottom"
             color="accent"
-            icon="close"
-            @click="setReply(null)"
           />
+        </q-page-sticky>
+        <q-inner-loading
+          :dark="$q.dark.isActive"
+          :showing="!!scrollDigest"
+          size="md"
+          label="Loading more messages..."
+        />
+      </q-page>
+    </q-page-container>
+    <q-footer bordered>
+      <div v-if="!!replyDigest" class="q-px-md q-pt-sm" ref="replyBox">
+        <!-- Reply box -->
+        <div class="row justify-end">
+          <div class="col-auto">
+            <q-btn
+              dense
+              flat
+              color="accent"
+              icon="close"
+              @click="setReply(null)"
+            />
+          </div>
+        </div>
+        <div class="row q-px-sm q-pt-sm">
+          <div class="col-12">
+            <chat-message-reply :payload-digest="replyDigest" />
+          </div>
         </div>
       </div>
-      <div class="row q-px-sm q-pt-sm">
-        <div class="col-12">
-          <chat-message-reply :payload-digest="replyDigest" />
-        </div>
-      </div>
-    </div>
-    <!-- Message box -->
-    <chat-input
-      @sendFileClicked="toSendFileDialog"
-      @giveLotusClicked="$emit('giveLotusClicked')"
-      ref="chatInput"
-      v-model:message="message"
-      v-model:stamp-amount="stampAmount"
-      @sendMessage="sendMessage"
-    />
-  </q-footer>
+      <!-- Message box -->
+      <chat-input
+        @sendFileClicked="toSendFileDialog"
+        @giveLotusClicked="$emit('giveLotusClicked')"
+        ref="chatInput"
+        v-model:message="message"
+        v-model:stamp-amount="stampAmount"
+        @sendMessage="sendMessage"
+      />
+    </q-footer>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/pages/CreatePost.vue
+++ b/src/pages/CreatePost.vue
@@ -1,78 +1,87 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-form @submit="post">
-      <q-card-section>
-        <q-input
-          label="Offering"
-          v-model="offering"
-          suffix="XPI"
-          :rules="[val => Number.parseFloat(val) || 'Invalid number']"
-          lazy-rules
-        />
-        <q-select
-          label="Topic"
-          :disable="!!getMessage(parentDigest)"
-          v-model="topic"
-          :options="topics"
-          @filter="filterTopics"
-          use-input
-          @new-value="createValue"
-          new-value-mode="add-unique"
-          input-debounce="0"
-          :rules="[
-            val =>
-              (val && val.length > 0 && /^[a-z0-9.-]+$/.test(val)) ||
-              'Only numbers, lowercase, periods and dashes allowed',
-            val =>
-              !val.split('.').some(val => val.length === 0) ||
-              'Topic segments not allowed to be empty',
-          ]"
-          lazy-rules
-        >
-          <template #no-option>
-            <q-item>
-              <q-item-section class="text-grey">No results</q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-        <q-input label="Post Title" v-model="title" />
-        <q-input
-          label="URL"
-          v-model="url"
-          :rules="[val => !val || validateUrl(val) || 'Invalid URL']"
-          lazy-rules
-        />
-        <q-card-section class="row q-pa-none">
-          <q-card-section class="col-xs-12 col-md q-pa-none q-pr-xs">
-            <q-input label="Message" v-model="message" type="textarea" />
-          </q-card-section>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card class="q-ma-sm">
+        <q-form @submit="post">
+          <q-card-section>
+            <q-input
+              label="Offering"
+              v-model="offering"
+              suffix="XPI"
+              :rules="[val => Number.parseFloat(val) || 'Invalid number']"
+              lazy-rules
+            />
+            <q-select
+              label="Topic"
+              :disable="!!getMessage(parentDigest)"
+              v-model="topic"
+              :options="topics"
+              @filter="filterTopics"
+              use-input
+              @new-value="createValue"
+              new-value-mode="add-unique"
+              input-debounce="0"
+              :rules="[
+                val =>
+                  (val && val.length > 0 && /^[a-z0-9.-]+$/.test(val)) ||
+                  'Only numbers, lowercase, periods and dashes allowed',
+                val =>
+                  !val.split('.').some(val => val.length === 0) ||
+                  'Topic segments not allowed to be empty',
+              ]"
+              lazy-rules
+            >
+              <template #no-option>
+                <q-item>
+                  <q-item-section class="text-grey">No results</q-item-section>
+                </q-item>
+              </template>
+            </q-select>
+            <q-input label="Post Title" v-model="title" />
+            <q-input
+              label="URL"
+              v-model="url"
+              :rules="[val => !val || validateUrl(val) || 'Invalid URL']"
+              lazy-rules
+            />
+            <q-card-section class="row q-pa-none">
+              <q-card-section class="col-xs-12 col-md q-pa-none q-pr-xs">
+                <q-input label="Message" v-model="message" type="textarea" />
+              </q-card-section>
 
-          <q-card-section
-            class="col-xs-12 col-md-6 q-pa-none q-pt-md"
-            v-show="this.message"
-          >
-            <div class="text-weight-bold text-caption">Message Preview</div>
-            <q-card-section class="q-pa-none q-pt-xs">
-              <span class="mdstyle" v-html="markedMessage" />
+              <q-card-section
+                class="col-xs-12 col-md-6 q-pa-none q-pt-md"
+                v-show="this.message"
+              >
+                <div class="text-weight-bold text-caption">Message Preview</div>
+                <q-card-section class="q-pa-none q-pt-xs">
+                  <span class="mdstyle" v-html="markedMessage" />
+                </q-card-section>
+              </q-card-section>
             </q-card-section>
           </q-card-section>
-        </q-card-section>
-      </q-card-section>
-      <q-card-actions align="right">
-        <q-btn @click="back" label="back" color="negative" class="q-ma-sm" />
-        <q-btn type="submit" label="Post" color="primary" class="q-ma-sm" />
-      </q-card-actions>
-    </q-form>
-  </q-card>
+          <q-card-actions align="right">
+            <q-btn
+              @click="back"
+              label="back"
+              color="negative"
+              class="q-ma-sm"
+            />
+            <q-btn type="submit" label="Post" color="primary" class="q-ma-sm" />
+          </q-card-actions>
+        </q-form>
+      </q-card>
 
-  <q-card class="q-ma-sm" v-if="getMessage(parentDigest)">
-    <q-card-section>Replying to:</q-card-section>
-    <a-message
-      :message="getMessage(parentDigest)"
-      :show-replies="false"
-      :compact="true"
-    />
-  </q-card>
+      <q-card class="q-ma-sm" v-if="getMessage(parentDigest)">
+        <q-card-section>Replying to:</q-card-section>
+        <a-message
+          :message="getMessage(parentDigest)"
+          :show-replies="false"
+          :compact="true"
+        />
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -1,28 +1,32 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-card-section>
-      <div class="text-h6">Profile</div>
-    </q-card-section>
-    <profile
-      v-model:name="name"
-      v-model:bio="bio"
-      v-model:avatar="avatar"
-      v-model:acceptancePrice="acceptancePrice"
-    />
-    <q-card-actions align="right">
-      <q-btn
-        :label="$t('profileDialog.cancel')"
-        color="negative"
-        @click="cancel"
-      />
-      <q-btn
-        :disable="identical"
-        :label="$t('profileDialog.update')"
-        color="primary"
-        @click="updateRelayData"
-      />
-    </q-card-actions>
-  </q-card>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">Profile</div>
+        </q-card-section>
+        <profile
+          v-model:name="name"
+          v-model:bio="bio"
+          v-model:avatar="avatar"
+          v-model:acceptancePrice="acceptancePrice"
+        />
+        <q-card-actions align="right">
+          <q-btn
+            :label="$t('profileDialog.cancel')"
+            color="negative"
+            @click="cancel"
+          />
+          <q-btn
+            :disable="identical"
+            :label="$t('profileDialog.update')"
+            color="primary"
+            @click="updateRelayData"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">

--- a/src/pages/Receive.vue
+++ b/src/pages/Receive.vue
@@ -1,60 +1,72 @@
 <template>
-  <q-card class="q-ma-sm">
-    <!-- New contact dialog -->
-    <q-dialog v-model="seedPhraseOpen">
-      <seed-phrase-dialog />
-    </q-dialog>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <!-- New contact dialog -->
+        <q-dialog v-model="seedPhraseOpen">
+          <seed-phrase-dialog />
+        </q-dialog>
 
-    <q-card-section>
-      <div class="text-h6">{{ $t('receiveBitcoinDialog.walletStatus') }}</div>
-    </q-card-section>
-    <q-card-section>
-      <div class="text-bold text-subtitle1 text-center">
-        {{ formattedBalance }}
-      </div>
-    </q-card-section>
-    <q-separator />
-    <q-card-section>
-      <div class="row">
-        <qrcode-vue
-          style="margin-left: auto; margin-right: auto"
-          :value="displayAddress"
-          :size="300"
-          level="H"
-        />
-      </div>
-      <div class="row">
-        <q-input class="fit" filled auto-grow v-model="displayAddress" readonly>
-          <template #after>
-            <q-btn
-              dense
-              color="primary"
-              flat
-              icon="swap_vert"
-              @click="toggleLegacy"
+        <q-card-section>
+          <div class="text-h6">
+            {{ $t('receiveBitcoinDialog.walletStatus') }}
+          </div>
+        </q-card-section>
+        <q-card-section>
+          <div class="text-bold text-subtitle1 text-center">
+            {{ formattedBalance }}
+          </div>
+        </q-card-section>
+        <q-separator />
+        <q-card-section>
+          <div class="row">
+            <qrcode-vue
+              style="margin-left: auto; margin-right: auto"
+              :value="displayAddress"
+              :size="300"
+              level="H"
             />
-            <q-btn
-              dense
-              color="primary"
-              flat
-              icon="content_copy"
-              @click="copyAddress"
-            />
-          </template>
-        </q-input>
-      </div>
-    </q-card-section>
-    <q-card-actions align="right">
-      <q-btn color="warning" @click="seedPhraseOpen = true">
-        {{ $t('receiveBitcoinDialog.showSeed') }}
-      </q-btn>
-      <q-btn
-        :label="$t('receiveBitcoinDialog.close')"
-        color="primary"
-        @click="close"
-      />
-    </q-card-actions>
-  </q-card>
+          </div>
+          <div class="row">
+            <q-input
+              class="fit"
+              filled
+              auto-grow
+              v-model="displayAddress"
+              readonly
+            >
+              <template #after>
+                <q-btn
+                  dense
+                  color="primary"
+                  flat
+                  icon="swap_vert"
+                  @click="toggleLegacy"
+                />
+                <q-btn
+                  dense
+                  color="primary"
+                  flat
+                  icon="content_copy"
+                  @click="copyAddress"
+                />
+              </template>
+            </q-input>
+          </div>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn color="warning" @click="seedPhraseOpen = true">{{
+            $t('receiveBitcoinDialog.showSeed')
+          }}</q-btn>
+          <q-btn
+            :label="$t('receiveBitcoinDialog.close')"
+            color="primary"
+            @click="close"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">

--- a/src/pages/Send.vue
+++ b/src/pages/Send.vue
@@ -1,44 +1,46 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-card-section>
-      <div class="text-h6">
-        {{ $t('sendAddressDialog.sendToAddress') }}
-      </div>
-    </q-card-section>
-    <q-card-section>
-      <q-input
-        class="text-bold text-h6"
-        v-model="address"
-        filled
-        dense
-        :placeholder="$t('sendAddressDialog.enterBitcoinCashAddress')"
-        ref="address"
-      />
-    </q-card-section>
-    <q-card-section>
-      <q-input
-        class="text-bold text-h6"
-        v-model="amount"
-        type="number"
-        filled
-        dense
-        :placeholder="$t('sendAddressDialog.enterAmount')"
-      />
-    </q-card-section>
-    <q-card-actions align="right">
-      <q-btn
-        :label="$t('sendAddressDialog.cancel')"
-        color="negative"
-        @click="cancel"
-      />
-      <q-btn
-        :disable="!isValid"
-        :label="$t('sendAddressDialog.send')"
-        color="primary"
-        @click="send()"
-      />
-    </q-card-actions>
-  </q-card>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">{{ $t('sendAddressDialog.sendToAddress') }}</div>
+        </q-card-section>
+        <q-card-section>
+          <q-input
+            class="text-bold text-h6"
+            v-model="address"
+            filled
+            dense
+            :placeholder="$t('sendAddressDialog.enterBitcoinCashAddress')"
+            ref="address"
+          />
+        </q-card-section>
+        <q-card-section>
+          <q-input
+            class="text-bold text-h6"
+            v-model="amount"
+            type="number"
+            filled
+            dense
+            :placeholder="$t('sendAddressDialog.enterAmount')"
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn
+            :label="$t('sendAddressDialog.cancel')"
+            color="negative"
+            @click="cancel"
+          />
+          <q-btn
+            :disable="!isValid"
+            :label="$t('sendAddressDialog.send')"
+            color="primary"
+            @click="send()"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script>

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -1,65 +1,72 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-splitter :model-value="110" unit="px" disable>
-      <template #before>
-        <q-tabs v-model="tab" vertical class="text-primary">
-          <q-tab
-            name="networking"
-            icon="cloud"
-            :label="$t('settings.networking')"
-          />
-          <q-tab
-            name="appearance"
-            icon="color_lens"
-            :label="$t('settings.appearance')"
-          />
-        </q-tabs>
-      </template>
-      <template #after>
-        <q-tab-panels
-          v-model="tab"
-          animated
-          swipeable
-          vertical
-          transition-prev="jump-up"
-          transition-next="jump-up"
-        >
-          <q-tab-panel name="networking">
-            <div class="row">
-              <q-input
-                outlined
-                v-model="updateInterval"
-                :label="$t('settings.contactRefreshInterval')"
-                type="number"
-                :hint="$t('settings.contactRefreshIntervalHint')"
-                style="width: 100%"
-                ref="contactRefreshInterval"
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <q-splitter :model-value="110" unit="px" disable>
+          <template #before>
+            <q-tabs v-model="tab" vertical class="text-primary">
+              <q-tab
+                name="networking"
+                icon="cloud"
+                :label="$t('settings.networking')"
               />
-            </div>
-          </q-tab-panel>
-          <q-tab-panel name="appearance">
-            <div class="row">
-              <q-toggle :label="$t('settings.darkMode')" v-model="darkMode" />
-            </div>
-          </q-tab-panel>
-        </q-tab-panels>
-      </template>
-    </q-splitter>
-    <q-card-actions align="right">
-      <q-btn
-        @click="cancel"
-        :label="$t('settings.cancelSettings')"
-        color="negative"
-        class="q-ma-sm"
-      />
-      <q-btn
-        @click="save"
-        :label="$t('settings.saveSettings')"
-        color="primary"
-        class="q-ma-sm"
-      />
-    </q-card-actions>
-  </q-card>
+              <q-tab
+                name="appearance"
+                icon="color_lens"
+                :label="$t('settings.appearance')"
+              />
+            </q-tabs>
+          </template>
+          <template #after>
+            <q-tab-panels
+              v-model="tab"
+              animated
+              swipeable
+              vertical
+              transition-prev="jump-up"
+              transition-next="jump-up"
+            >
+              <q-tab-panel name="networking">
+                <div class="row">
+                  <q-input
+                    outlined
+                    v-model="updateInterval"
+                    :label="$t('settings.contactRefreshInterval')"
+                    type="number"
+                    :hint="$t('settings.contactRefreshIntervalHint')"
+                    style="width: 100%"
+                    ref="contactRefreshInterval"
+                  />
+                </div>
+              </q-tab-panel>
+              <q-tab-panel name="appearance">
+                <div class="row">
+                  <q-toggle
+                    :label="$t('settings.darkMode')"
+                    v-model="darkMode"
+                  />
+                </div>
+              </q-tab-panel>
+            </q-tab-panels>
+          </template>
+        </q-splitter>
+        <q-card-actions align="right">
+          <q-btn
+            @click="cancel"
+            :label="$t('settings.cancelSettings')"
+            color="negative"
+            class="q-ma-sm"
+          />
+          <q-btn
+            @click="save"
+            :label="$t('settings.saveSettings')"
+            color="primary"
+            class="q-ma-sm"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">

--- a/src/pages/Setup.vue
+++ b/src/pages/Setup.vue
@@ -1,9 +1,5 @@
 <template>
-  <q-layout
-    view="lhh LpR lff"
-    container
-    class="hide-scrollbar absolute full-width"
-  >
+  <div>
     <q-header>
       <q-toolbar class="q-pl-sm">
         <q-btn
@@ -18,7 +14,7 @@
     </q-header>
 
     <q-page-container>
-      <q-page>
+      <q-page class="q-ma-none q-pa-sm">
         <q-stepper
           v-model="step"
           ref="stepper"
@@ -66,14 +62,14 @@
                 class="q-ml-sm"
               />
             </q-stepper-navigation>
-            <q-banner inline-actions class="text-white bg-red">{{
-              $t('setup.seedWarning')
-            }}</q-banner>
+            <q-banner inline-actions class="text-white bg-red">
+              {{ $t('setup.seedWarning') }}
+            </q-banner>
           </template>
         </q-stepper>
       </q-page>
     </q-page-container>
-  </q-layout>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/pages/WipeWallet.vue
+++ b/src/pages/WipeWallet.vue
@@ -1,30 +1,34 @@
 <template>
-  <q-card class="q-ma-sm">
-    <q-card-section>
-      <div class="text-h6">WARNING!</div>
-    </q-card-section>
-    <q-card-section>
-      <div>
-        This will delete all messages from the remove server and consolidate any
-        funds associated with them back into your HD wallet.
-      </div>
-      <div>This cannot be undoned!</div>
-    </q-card-section>
-    <q-card-actions align="right">
-      <q-btn
-        @click="cancel"
-        :label="$t('wipeWallet.cancel')"
-        color="negative"
-        class="q-ma-sm"
-      />
-      <q-btn
-        @click="wipeWallet"
-        :label="$t('wipeWallet.wipe')"
-        color="primary"
-        class="q-ma-sm"
-      />
-    </q-card-actions>
-  </q-card>
+  <q-page-container>
+    <q-page class="q-ma-none q-pa-sm">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">WARNING!</div>
+        </q-card-section>
+        <q-card-section>
+          <div>
+            This will delete all messages from the remove server and consolidate
+            any funds associated with them back into your HD wallet.
+          </div>
+          <div>This cannot be undoned!</div>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn
+            @click="cancel"
+            :label="$t('wipeWallet.cancel')"
+            color="negative"
+            class="q-ma-sm"
+          />
+          <q-btn
+            @click="wipeWallet"
+            :label="$t('wipeWallet.wipe')"
+            color="primary"
+            class="q-ma-sm"
+          />
+        </q-card-actions>
+      </q-card>
+    </q-page>
+  </q-page-container>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Previously we used nested QLayouts early on in development because we
didn't understand out nested RouterViews worked. These "container"
versions of QLayout come with a lot of problems that caused rendering
issues. This commit removes them and adjusts where QPageContainer and
QPage are placed so that the nested layouts are no longer necessary.
This should speed up rendering, and hopefully fix the weird keyboard
issue on mobile.