### PR TITLE
Fix bug around updating the stored active chat

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -12,9 +12,7 @@
             dense
             flat
             icon="add"
-            @click="
-              () => openPage(this.$router, this.$route.path, '/add-topic')
-            "
+            @click="() => openPage(this.$router, '/add-topic')"
           />
         </q-item>
         <q-separator />
@@ -37,9 +35,7 @@
             dense
             flat
             icon="add"
-            @click="
-              () => openPage(this.$router, this.$route.path, '/add-contact')
-            "
+            @click="() => openPage(this.$router, '/add-contact')"
           />
         </q-item>
         <q-separator />
@@ -80,7 +76,7 @@ import { useChatStore } from '../../stores/chats'
 import { useWalletStore } from '../../stores/wallet'
 import { useTopicStore } from 'src/stores/topics'
 
-import { openPage } from '../../utils/routes'
+import { openChat, openPage } from '../../utils/routes'
 
 export default defineComponent({
   setup() {
@@ -93,7 +89,6 @@ export default defineComponent({
     return {
       getSortedChatOrder,
       balance,
-      setStoredActiveChat: chatStore.setActiveChat,
       topics: getTopics,
       openPage,
     }
@@ -115,7 +110,7 @@ export default defineComponent({
   },
   methods: {
     setActiveChat(address: string) {
-      this.setStoredActiveChat(address)
+      openChat(this.$router, address)
     },
     toggleMyDrawerOpen() {
       this.$emit('toggleMyDrawerOpen')

--- a/src/components/panels/ChatRightDrawer.vue
+++ b/src/components/panels/ChatRightDrawer.vue
@@ -23,16 +23,6 @@
       />
     </q-dialog>
     -->
-    <!-- Contact book dialog -->
-    <q-dialog v-model="contactBookOpen">
-      <contact-book-dialog
-        :contact-click="
-          function (shareAddr, contact) {
-            return shareContact({ currentAddr: address, shareAddr })
-          }
-        "
-      />
-    </q-dialog>
 
     <!-- Contact card -->
     <contact-card
@@ -91,7 +81,6 @@
 import { defineComponent } from 'vue'
 
 import ContactCard from './ContactCard.vue'
-import ContactBookDialog from '../dialogs/ContactBookDialog.vue'
 import SendLotusDialog from '../dialogs/SendLotusDialog.vue'
 import { useContactStore } from 'src/stores/contacts'
 import { useChatStore } from 'src/stores/chats'
@@ -102,7 +91,6 @@ export default defineComponent({
     const contactStore = useContactStore()
 
     return {
-      shareContact: chatsStore.shareContact,
       setStampAmount: chatsStore.setStampAmount,
       setNotify: contactStore.setNotify,
       getNotify: contactStore.getNotify,
@@ -111,7 +99,6 @@ export default defineComponent({
   },
   components: {
     ContactCard,
-    ContactBookDialog,
     SendLotusDialog,
   },
   props: {
@@ -155,7 +142,6 @@ export default defineComponent({
     return {
       confirmClearOpen: false,
       confirmDeleteOpen: false,
-      contactBookOpen: false,
       sendBitcoinOpen: false,
     }
   },

--- a/src/components/panels/LeftDrawer.vue
+++ b/src/components/panels/LeftDrawer.vue
@@ -44,7 +44,7 @@ import ChatList from '../chat/ChatList.vue'
 import SettingsPanel from '../panels/SettingsPanel.vue'
 import RelayConnectDialog from '../dialogs/RelayConnectDialog.vue'
 import { formatBalance } from '../../utils/formatting'
-import { openPage } from '../../utils/routes'
+import { openChat, openPage } from '../../utils/routes'
 import { useWalletStore } from 'src/stores/wallet'
 import { useChatStore } from 'src/stores/chats'
 import { useAppearanceStore } from 'src/stores/appearance'
@@ -62,10 +62,8 @@ export default defineComponent({
     const contacts = useContactStore()
 
     return {
-      setActiveChat: chats.setActiveChat,
       addDefaultContact: contacts.addDefaultContact,
       darkMode: computed(() => appearance.darkMode),
-      activeCharAddr: computed(() => chats.activeChatAddr),
       getContact: contacts.getContact,
       lastReceived: chats.getLastReceived,
       totalUnread: chats.totalUnread,
@@ -116,11 +114,10 @@ export default defineComponent({
     },
     contactClicked(address: string) {
       this.contactBookOpen = false
-
-      return this.setActiveChat(address)
+      openChat(this.$router, address)
     },
     receiveECash() {
-      openPage(this.$router, this.$route.path, '/receive')
+      openPage(this.$router, '/receive')
     },
   },
   computed: {

--- a/src/components/panels/SettingsPanel.vue
+++ b/src/components/panels/SettingsPanel.vue
@@ -113,7 +113,7 @@ import { defineComponent } from 'vue'
 
 import ContactCard from './ContactCard.vue'
 import ContactBookDialog from '../dialogs/ContactBookDialog.vue'
-import { openPage } from '../../utils/routes'
+import { openChat, openPage } from '../../utils/routes'
 import { useChatStore } from 'src/stores/chats'
 import { useProfileStore } from 'src/stores/my-profile'
 import { storeToRefs } from 'pinia'
@@ -125,7 +125,6 @@ export default defineComponent({
     const { profile, inbox } = storeToRefs(myProfile)
     return {
       deleteMessage: chats.deleteMessage,
-      setActiveChat: chats.setActiveChat,
       profile,
       inbox,
     }
@@ -158,22 +157,25 @@ export default defineComponent({
       this.contactBookOpen = false
     },
     openSettings() {
-      openPage(this.$router, this.$route.path, '/settings')
+      openPage(this.$router, '/settings')
     },
     openProfile() {
-      openPage(this.$router, this.$route.path, '/profile')
+      openPage(this.$router, '/profile')
     },
     receiveECash() {
-      openPage(this.$router, this.$route.path, '/receive')
+      openPage(this.$router, '/receive')
     },
     sendECash() {
-      openPage(this.$router, this.$route.path, '/send')
+      openPage(this.$router, '/send')
     },
     newContact() {
-      openPage(this.$router, this.$route.path, '/add-contact')
+      openPage(this.$router, '/add-contact')
     },
     deleteForever() {
-      openPage(this.$router, this.$route.path, '/wipe-wallet')
+      openPage(this.$router, '/wipe-wallet')
+    },
+    setActiveChat(address: string) {
+      openChat(this.$router, address)
     },
   },
   computed: {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -42,6 +42,7 @@ import { useAppearanceStore } from 'src/stores/appearance'
 import { useProfileStore } from 'src/stores/my-profile'
 import { useContactStore } from 'src/stores/contacts'
 import { useChatStore } from 'src/stores/chats'
+import { openChat } from 'src/utils/routes'
 
 const compactWidth = 70
 const compactCutoff = 325
@@ -75,13 +76,15 @@ export default defineComponent({
       if (!newAddress) {
         return
       }
-      router.push(`/chat/${newAddress}`).catch(() => {
-        // Don't care. Probably duplicate route
-      })
+      openChat(router, newAddress)
     })
 
+    const contactClicked = (newAddress: string) => {
+      openChat(router, newAddress)
+    }
+
     return {
-      setActiveChat: chatStore.setActiveChat,
+      contactClicked,
       addDefaultContact: contacts.addDefaultContact,
       refreshContacts: contacts.refreshContacts,
       // FIXME: Some kind of race condition here where if this is computed,
@@ -99,7 +102,7 @@ export default defineComponent({
   data() {
     return {
       trueSplitterRatio: compactCutoff,
-      myDrawerOpen: !!this.activeChatAddr as boolean,
+      myDrawerOpen: true,
       contactDrawerOpen: false as boolean,
       contactBookOpen: false,
       compact: false,
@@ -149,9 +152,6 @@ export default defineComponent({
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         this.toggleContactBookOpen()
       }
-    },
-    contactClicked(newAddress: string) {
-      this.setActiveChat(newAddress)
     },
     setupConnections() {
       // Not currently setup. User needs to go through setup flow first

--- a/src/pages/AddContact.vue
+++ b/src/pages/AddContact.vue
@@ -84,7 +84,7 @@ import { KeyserverHandler } from '../cashweb/keyserver'
 import { toAPIAddress } from '../utils/address'
 import { keyservers, networkName } from '../utils/constants'
 import { PublicKey } from 'bitcore-lib-xpi'
-import { useChatStore } from 'src/stores/chats'
+import { openChat } from 'src/utils/routes'
 
 export default defineComponent({
   data() {
@@ -95,12 +95,10 @@ export default defineComponent({
   },
   setup() {
     const contactStore = useContactStore()
-    const chats = useChatStore()
 
     return {
       addressRef: ref<QInput | null>(null),
       addContactToStore: contactStore.addContact,
-      openChat: chats.openChat,
     }
   },
   computed: {
@@ -146,7 +144,7 @@ export default defineComponent({
         address: cashAddress,
         contact: this.contact,
       })
-      this.openChat(this.address)
+      openChat(this.$router, this.address)
     },
     cancel() {
       window.history.length > 1 ? this.$router.go(-1) : this.$router.push('/')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,14 +8,22 @@ import type { RouteLocationNormalized, NavigationGuardNext } from 'vue-router'
 import { createRoutes } from './routes'
 import { useContactStore } from 'src/stores/contacts'
 import { useProfileStore } from 'src/stores/my-profile'
+import { useChatStore } from 'src/stores/chats'
 
 const unprotectedRoutes = ['/', '/setup', '/forum', '/changelog']
 const protectedRoutes = ['/forum/new-post']
 
-async function addContactFromNavigation(address: string) {
-  const contacsStore = useContactStore()
+async function ensureChatState(address?: string) {
+  const chatStore = useChatStore()
+  if (!address) {
+    chatStore.activeChatAddr = null
+    return
+  }
+
   try {
-    contacsStore.fetchAndAddContact({ address, contact: {} })
+    const contactsStore = useContactStore()
+    contactsStore.fetchAndAddContact({ address, contact: {} })
+    chatStore.activeChatAddr = address
   } catch (ex) {
     console.error('addContactFromNavigation error:', ex)
   }
@@ -28,14 +36,17 @@ export default () => {
     from: RouteLocationNormalized,
     next: NavigationGuardNext,
   ) {
-    const profileStore = useProfileStore()
     if (
       to.fullPath.startsWith('/chat') &&
       to.params.address &&
       typeof to.params.address === 'string'
     ) {
-      addContactFromNavigation(to.params.address as string)
+      ensureChatState(to.params.address as string)
+    } else {
+      ensureChatState()
     }
+
+    const profileStore = useProfileStore()
     console.log(
       'Navigating to',
       to.fullPath,

--- a/src/stores/chats.ts
+++ b/src/stores/chats.ts
@@ -339,18 +339,6 @@ export const useChatStore = defineStore('chats', {
       this.messages = {}
       this.lastReceived = null
     },
-    openChat(address: string) {
-      const displayAddress = toDisplayAddress(address)
-
-      if (!(displayAddress in this.chats)) {
-        this.chats[displayAddress] = {
-          ...defaultContactObject,
-          messages: [],
-          address: displayAddress,
-        }
-      }
-      this.activeChatAddr = displayAddress
-    },
     sendMessageLocal({
       address,
       senderAddress,
@@ -438,10 +426,6 @@ export const useChatStore = defineStore('chats', {
     },
     deleteChat(address: string) {
       const displayAddress = toDisplayAddress(address)
-
-      if (this.activeChatAddr === displayAddress) {
-        this.activeChatAddr = null
-      }
       delete this.chats[displayAddress]
     },
     setStampAmount({
@@ -457,31 +441,6 @@ export const useChatStore = defineStore('chats', {
         return
       }
       chat.stampAmount = stampAmount
-    },
-    shareContact({ shareAddr }: { shareAddr: string }) {
-      this.setActiveChat(shareAddr)
-    },
-    setActiveChat(address: string) {
-      // make sure address is defined, e.g. Forum is undefined
-      if (address) {
-        const contacts = useContactStore()
-        contacts.refresh(address)
-        this.readAll(address)
-      }
-      // make sure address is defined, e.g. Forum is undefined
-      if (!address) {
-        this.activeChatAddr = null
-        return
-      }
-      const displayAddress = toDisplayAddress(address)
-      if (!(displayAddress in this.chats)) {
-        this.chats[displayAddress] = {
-          ...defaultContactObject,
-          messages: [],
-          address: displayAddress,
-        }
-      }
-      this.activeChatAddr = displayAddress
     },
     async receiveMessages(messageWrappers: ReceivedMessageWrapper[]) {
       console.log('receiving messages')
@@ -554,7 +513,7 @@ export const useChatStore = defineStore('chats', {
             contact.profile.name ?? 'Unknown',
             body,
             contact.profile.avatar ?? '',
-            async () => this.setActiveChat(copartyAddress),
+            async () => (this.activeChatAddr = copartyAddress),
           )
         }
       }

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -312,8 +312,6 @@ export const useContactStore = defineStore('contacts', {
           contact,
         })
       }
-      const chats = useChatStore()
-      chats.setActiveChat(displayAddress)
     },
     addDefaultContact({ address, name }: { address: string; name: string }) {
       if (this.isContact(address)) {
@@ -332,7 +330,7 @@ export const useContactStore = defineStore('contacts', {
       }
       this.addContact({ address: address, contact })
       const chats = useChatStore()
-      chats.openChat(address)
+      chats.activeChatAddr = address
     },
     async refreshContacts() {
       for (const address of Object.keys(this.contacts)) {

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -8,11 +8,17 @@ export const settingsRoutes = [
   '/add-contact',
 ]
 
-export function openPage(router: Router, currentRoute: string, route: string) {
+export function openPage(router: Router, route: string) {
+  const currentRoute = router.currentRoute.value.path
   for (const settingsRoute of settingsRoutes) {
     if (currentRoute.startsWith(settingsRoute)) {
       return router.replace(route)
     }
   }
   return router.push(route)
+}
+
+export function openChat(router: Router, address: string) {
+  const chatRoute = `/chat/${address}`
+  return openPage(router, chatRoute)
 }


### PR DESCRIPTION
Update activeChatAddr from within the router, and ensure it is set to
null when the current route is no longer a chat. This fixes a bug where
in some cases a non-chat route was selected and the user would not be
able to navigate back to the appropriate user due to `acitveChatAddr`
still being set to that contact.