### PR TITLE
Don't automatically show drawer on small screens

### DIFF
--- a/src/layouts/TopicLayout.vue
+++ b/src/layouts/TopicLayout.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <q-drawer v-model="showTopicDrawer" side="right" :breakpoint="800">
+    <q-drawer
+      v-model="showTopicDrawer"
+      side="right"
+      :breakpoint="800"
+      show-if-above
+    >
       <topic-drawer :topic="topic" />
     </q-drawer>
 
@@ -64,7 +69,7 @@ export default defineComponent({
     const topicsStore = useTopicStore()
     const routeParams = router.currentRoute.value.params
     const topic = routeParams['topic']
-    const showTopicDrawer = ref(true)
+    const showTopicDrawer = ref(false)
     const toggleTopicDrawer = () => {
       showTopicDrawer.value = !showTopicDrawer.value
     }


### PR DESCRIPTION
Topic drawer was automatically opening on mobile and quite annoying.
This should make it not do that, but still show up on desktop.
