### PR TITLE
Wipe out legacy topic serialization

### DIFF
--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -350,6 +350,9 @@ export const useTopicStore = defineStore('topics', {
         if (!('topics' in deserializedState)) {
           deserializedState.topics = []
         }
+        if (!(deserializedState.topics instanceof Array)) {
+          deserializedState.topics = []
+        }
         assert(deserializedState.topics)
         // This should work on the old serialized state
         for (const topic of Object.values(deserializedState.topics)) {


### PR DESCRIPTION
If the user had the old format for saving topic data, blow it out.
