### PR TITLE
Fix restoration of messageIndex

### DIFF
--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -332,7 +332,7 @@ export const useTopicStore = defineStore('topics', {
         deserializedState: Partial<ReducedState>,
       ): State => {
         const hydratedState: State = {
-          messageIndex: {},
+          messageIndex: deserializedState.messageIndex ?? {},
           // Add default topics
           topics: Object.fromEntries(
             defaultTopics.map(topic => {
@@ -344,7 +344,7 @@ export const useTopicStore = defineStore('topics', {
         if (!('messageIndex' in deserializedState)) {
           deserializedState.messageIndex = {}
         }
-        const messageIndex = deserializedState.messageIndex
+        const messageIndex = hydratedState.messageIndex
         assert(messageIndex)
 
         if (!('topics' in deserializedState)) {


### PR DESCRIPTION
The previous commit to fix topics left out the messageIndex restoration,
which led to topics loading as blank after a second refresh. Ensure
messageIndex is properly restored.
