### PR TITLE
Increase default profile update interval to 1 hour

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -86,7 +86,7 @@ export const defaultContacts = [
 export const notificationTimeout = 4000
 
 // Contact defaults
-export const defaultUpdateInterval = 60 * 10 * 1_000
+export const defaultUpdateInterval = 1000 * 60 * 60 * 1 * 1
 
 // Formatting constants
 // TODO: Generate this


### PR DESCRIPTION
This is using quite a bit of bandwidth because people are uploading
large avatar pictures (and gifs). We need a way to ensure people don't
do this in the future. However, for now just update less as leaving
stamp open uses a ton of bandwidth over time.