### PR TITLE
Don't add subtopics when voting

### DIFF
--- a/src/components/topic/TopicMessage.vue
+++ b/src/components/topic/TopicMessage.vue
@@ -87,6 +87,10 @@ export default defineComponent({
       type: Object as PropType<ForumMessage>,
       required: true,
     },
+    topic: {
+      required: true,
+      type: String,
+    },
   },
   methods: {
     markedMessage(text?: string) {
@@ -99,7 +103,7 @@ export default defineComponent({
     // Still need to implement a `useWallet` method.
     addVotes(votes: number) {
       const topicStore = useTopicStore()
-      const topic = this.message.topic
+      const topic = this.topic
       this.voteAmount += votes
       console.log('adding votes', this.voteAmount)
       if (this.timeoutId) {
@@ -118,7 +122,7 @@ export default defineComponent({
           payloadDigest: this.message?.payloadDigest,
           satoshis:
             this.voteAmount * (topicStore.topics[topic]?.offering ?? 1_000_000),
-          topic: this.message.topic,
+          topic,
         })
         this.voteAmount = 0
       }, 1_000)

--- a/src/pages/Topic.vue
+++ b/src/pages/Topic.vue
@@ -6,7 +6,7 @@
   >
     <template v-if="messages?.length > 0">
       <template v-for="message in messages" :key="message.payloadDigest">
-        <topic-message :message="message" />
+        <topic-message :message="message" :topic="topic" />
       </template>
     </template>
     <template v-else>


### PR DESCRIPTION
Currently, due to a bug, if there is a message posted to a subtopic of
something subscribed to, and you vote for it, it will only vote 1 XPI
and also subscribe to the topic. This commit fixes it so that the
software does not add the new topic.