### PR TITLE
Add `useWallet` and `useRelayClient` for composition API

### DIFF
--- a/src/boot/setup-apis.ts
+++ b/src/boot/setup-apis.ts
@@ -16,6 +16,7 @@ import { useContactStore } from 'src/stores/contacts'
 import { useAppearanceStore } from 'src/stores/appearance'
 import { useForumStore } from 'src/stores/forum'
 import { useTopicStore } from 'src/stores/topics'
+import { useRelayClient, useWallet } from 'src/utils/clients'
 
 function instrumentIndexerClient({
   chronikWs,
@@ -158,9 +159,9 @@ export default boot(async ({ app }) => {
   const topicStore = useTopicStore()
   await topicStore.restored
 
-  app.config.globalProperties.$wallet = wallet
+  app.config.globalProperties.$wallet = useWallet(wallet)
   app.config.globalProperties.$indexer = indexerObservables
-  app.config.globalProperties.$relayClient = relayClient
+  app.config.globalProperties.$relayClient = useRelayClient(relayClient)
   app.config.globalProperties.$relay = relayObservables
   app.config.globalProperties.$status = status
 })

--- a/src/utils/clients.ts
+++ b/src/utils/clients.ts
@@ -1,0 +1,21 @@
+import assert from 'assert'
+import RelayClient from 'src/cashweb/relay'
+import { Wallet } from 'src/cashweb/wallet'
+
+let wallet: Wallet | null = null
+export function useWallet(newWallet?: Wallet) {
+  if (newWallet) {
+    wallet = newWallet
+  }
+  assert(wallet, 'Attempting to use wallet before setup')
+  return wallet
+}
+
+let relayClient: RelayClient | null = null
+export function useRelayClient(newRelayClient?: RelayClient) {
+  if (newRelayClient) {
+    relayClient = newRelayClient
+  }
+  assert(relayClient, 'Attempting to use relayClient before setup')
+  return relayClient
+}


### PR DESCRIPTION
A lot of components require use of a mix of the composition and class
APIs in vue due to not having a way to get at the wallet without `this`.
Thus, they cannot be used from `setup()` functions. This commit adds a
singleton for these two objects so they can be used from within the
composition API.