### PR TITLE
Change how chat bubbles are shown/hidden

### DIFF
--- a/src/components/chat/messages/ChatMessage.vue
+++ b/src/components/chat/messages/ChatMessage.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    style="width: 100%"
-    @mouseover="mouseoverCheckMobile()"
-    @mouseleave="provided.mouseover = false"
-  >
+  <div style="width: 100%">
     <!-- Transaction Dialog -->
     <q-dialog v-model="transactionDialog">
       <!-- Switch to outpoints -->
@@ -105,14 +101,10 @@ export default defineComponent({
     return {
       transactionDialog: false,
       deleteDialog: false,
-      provided: {
-        mouseover: false,
-      },
     }
   },
   setup() {
     const chats = useChatStore()
-
     return {
       deleteMessage: chats.deleteMessage,
       getStampAmount: chats.getStampAmount,
@@ -147,11 +139,6 @@ export default defineComponent({
       default: () => -1,
     },
   },
-  provide() {
-    return {
-      provided: this.provided,
-    }
-  },
   methods: {
     handleReplyDivClick(args: MouseEvent) {
       this.$emit('replyDivClick', args)
@@ -176,10 +163,6 @@ export default defineComponent({
     },
     replyClicked(args: { address: string; payloadDigest: string }) {
       this.$emit('replyClicked', args)
-    },
-    mouseoverCheckMobile() {
-      // only set mouseover if not on mobile
-      this.provided.mouseover = !this.$q.platform.is.mobile
     },
   },
   computed: {
@@ -217,12 +200,10 @@ export default defineComponent({
           : ''
       if ((text && text.length >= textLen) || image) {
         base += 1
-        return String(base)
       } else if (reply) {
         base -= 1
-        return String(base)
       }
-      return undefined
+      return String(base)
     },
     shortTimestamp() {
       switch (this.message.status) {

--- a/src/components/chat/messages/ChatMessageSuffixButtons.vue
+++ b/src/components/chat/messages/ChatMessageSuffixButtons.vue
@@ -9,15 +9,19 @@
       @click="$emit('resendClick')"
     />
   </div>
-  <div v-else-if="status === 'confirmed'">
+  <div
+    v-else-if="status === 'confirmed'"
+    @mouseover="mouseoverCheckMobile()"
+    @mouseleave="mouseOver = false"
+  >
     <q-btn
       dense
       flat
       icon="more_vert"
-      class="q-btn mobile-only"
+      class="q-btn"
       padding="xs"
       @click="menuClicked"
-      v-show="!showMenu"
+      v-show="!showMenu && !mouseOver"
     />
     <template v-for="button in buttonNames" :key="button">
       <q-btn
@@ -27,14 +31,14 @@
         padding="xs"
         class="q-btn"
         @click="buttonClicked"
-        v-show="provided?.mouseover || showMenu"
+        v-show="mouseOver ?? showMenu"
       />
     </template>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, inject } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { useQuasar } from 'quasar'
 
 const ButtonNames = ['reply', 'forward', 'info', 'delete'] as const
@@ -54,11 +58,16 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const showMenu = ref(false)
-    const provided = inject<{ mouseover: boolean }>('provided')
+    const mouseOver = ref(false)
+    const $q = useQuasar()
     return {
-      provided,
+      mouseOver,
       showMenu,
       buttonNames: ButtonNames,
+      mouseoverCheckMobile() {
+        // only set mouseover if not on mobile
+        mouseOver.value = !$q.platform.is.mobile
+      },
       menuClicked() {
         showMenu.value = !showMenu.value
       },
@@ -69,7 +78,6 @@ export default defineComponent({
           const clickEvent = `${buttonType}Click` as const
           emit(clickEvent)
         }
-        const $q = useQuasar()
         // Only flip boolean state if using 3-dot menu button on mobile
         if ($q.platform.is.mobile) {
           showMenu.value = !showMenu.value


### PR DESCRIPTION
Ensure chat bubbles have a width enough to show menu items, so it
doesn't bounce around in size. Also, always show menu expansion option
even on desktop.
