### PR TITLE
Fix type issues in Chat.vue

### DIFF
--- a/src/cashweb/types/messages.ts
+++ b/src/cashweb/types/messages.ts
@@ -43,6 +43,7 @@ export interface Message {
   items: Array<MessageItem>
   outpoints: Array<Utxo>
   senderAddress: string
+  payloadDigest: string
 }
 
 export interface MessageWrapper {

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -16,13 +16,11 @@
                 :index="index"
                 :message="msg"
                 :address="address"
-                :name="getContact(msg.outbound).name"
+                :name="getContact(msg.outbound).name ?? 'unknown'"
                 :chat-width="chatWidth"
                 :payload-digest="msg.payloadDigest"
                 :ref="msg.payloadDigest"
-                @replyClicked="
-                  ({ address, payloadDigest }) => setReply(payloadDigest)
-                "
+                @replyClicked="({ payloadDigest }) => setReply(payloadDigest)"
                 @replyDivClick="scrollToMessage"
               />
             </template>


### PR DESCRIPTION
Add `payloadDigest` to the `Message` type to avoid typeerrors in
Chat.vue, also fix a null/undefined check
