### PR TITLE
Ensure all spaces are replaced by dashes in topic names

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@ export default defineComponent({
           const normalizedTopicPart = topicPart
             .trim()
             .toLowerCase()
-            .replace(/\s/, '-')
+            .replace(/\s/g, '-')
           const joinedTopic = [lastTopic, normalizedTopicPart].join('.')
           return [...topics, lastTopic, joinedTopic]
         },


### PR DESCRIPTION
Automatic local topics were not replacing multiple spaces with dashes.
This changes it to a global replace.