### PR TITLE
Move topics to their own tab on the left drawer

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -2,29 +2,6 @@
   <div class="full-width column col">
     <q-scroll-area class="q-px-none col">
       <q-list>
-        <chat-list-link
-          title="Login/Sign Up"
-          route="/setup"
-          icon="login"
-          v-if="!$status.setup"
-        />
-        <q-separator />
-        <q-item>
-          <q-item-section>
-            <q-item-label>Topics</q-item-label>
-          </q-item-section>
-          <q-space />
-          <q-btn
-            dense
-            flat
-            icon="add"
-            @click="() => openPage(this.$router, '/add-topic')"
-          />
-        </q-item>
-        <q-separator />
-        <template v-for="topic in topics" :key="topic">
-          <topic-list-link :topic="topic" icon="forum" />
-        </template>
         <q-separator />
         <q-item>
           <q-item-section>
@@ -35,7 +12,7 @@
             dense
             flat
             icon="add"
-            @click="() => openPage(this.$router, '/add-contact')"
+            @click="() => openPage($router, '/add-contact')"
           />
         </q-item>
         <q-separator />
@@ -45,7 +22,7 @@
             v-for="contact in getSortedChatOrder"
             :key="contact.address"
             :chat-address="contact.address"
-            :value-unread="formatBalance(contact.totalUnreadValue)"
+            :value-unread="formatAmount(contact.totalUnreadValue)"
             :num-unread="contact.totalUnreadMessages"
             :compact="compact"
             @click="setActiveChat(contact.address)"
@@ -67,30 +44,30 @@ import { defineComponent } from 'vue'
 import { storeToRefs } from 'pinia'
 
 import ChatListItem from './ChatListItem.vue'
-import ChatListLink from './ChatListLink.vue'
-// FIXME: The current file needs to be moved around and refactored to make sense
-// with topics system.
-import TopicListLink from '../topic/TopicListLink.vue'
-import { formatBalance } from '../../utils/formatting'
 import { useChatStore } from '../../stores/chats'
-import { useWalletStore } from '../../stores/wallet'
-import { useTopicStore } from 'src/stores/topics'
 
 import { openChat, openPage } from '../../utils/routes'
+import { useRouter } from 'vue-router'
+import { formatBalance } from 'src/utils/formatting'
 
 export default defineComponent({
   setup() {
     const chatStore = useChatStore()
     const { getSortedChatOrder } = storeToRefs(chatStore)
-    const walletStore = useWalletStore()
-    const { balance } = storeToRefs(walletStore)
-    const { getTopics } = storeToRefs(useTopicStore())
 
+    const router = useRouter()
     return {
       getSortedChatOrder,
-      balance,
-      topics: getTopics,
       openPage,
+      setActiveChat(address: string) {
+        openChat(router, address)
+      },
+      formatAmount(amount?: number) {
+        if (!amount) {
+          return
+        }
+        return formatBalance(amount)
+      },
     }
   },
   props: {
@@ -99,28 +76,8 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ['toggleMyDrawerOpen'],
   components: {
     ChatListItem,
-    ChatListLink,
-    TopicListLink,
-  },
-  data() {
-    return {}
-  },
-  methods: {
-    setActiveChat(address: string) {
-      openChat(this.$router, address)
-    },
-    toggleMyDrawerOpen() {
-      this.$emit('toggleMyDrawerOpen')
-    },
-    formatBalance(balance?: number) {
-      if (!balance) {
-        return
-      }
-      return formatBalance(balance)
-    },
   },
 })
 </script>

--- a/src/components/topic/TopicList.vue
+++ b/src/components/topic/TopicList.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="full-width column col">
+    <q-scroll-area class="q-px-none col">
+      <q-list>
+        <q-separator />
+        <q-item>
+          <q-item-section>
+            <q-item-label>Topics</q-item-label>
+          </q-item-section>
+          <q-space />
+          <q-btn
+            dense
+            flat
+            icon="add"
+            @click="() => openPage($router, '/add-topic')"
+          />
+        </q-item>
+        <q-separator />
+        <template v-for="topic in topics" :key="topic">
+          <topic-list-link :topic="topic" icon="forum" />
+        </template>
+      </q-list>
+    </q-scroll-area>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { storeToRefs } from 'pinia'
+
+import TopicListLink from './TopicListLink.vue'
+import { useTopicStore } from 'src/stores/topics'
+
+import { openPage } from '../../utils/routes'
+
+export default defineComponent({
+  setup() {
+    const { getTopics } = storeToRefs(useTopicStore())
+
+    return {
+      topics: getTopics,
+      openPage,
+    }
+  },
+  components: {
+    TopicListLink,
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.active-chat-list-item {
+  background: var(--q-color-bg-active);
+  color: #f0409b;
+}
+</style>

--- a/src/components/topic/TopicListLink.vue
+++ b/src/components/topic/TopicListLink.vue
@@ -1,12 +1,6 @@
 <template>
   <!-- TODO: We need a better way to handle multiple pages and types of chats. -->
   <q-item :active="isActive" active-class="active-chat-list-item">
-    <q-item-section avatar clickable @click="setRoute()">
-      <q-avatar rounded>
-        <img src="~assets/stamp-icon.png" v-if="!icon" />
-        <q-icon :name="icon" v-if="icon" />
-      </q-avatar>
-    </q-item-section>
     <q-item-section clickable @click="setRoute()">
       <q-item-label>{{ topic }}</q-item-label>
     </q-item-section>


### PR DESCRIPTION
Topics could end up having the impact of occluding DMs. This commit reorganizes the left drawer to have a specific topic tab. Also, add in a badge to the DM view so that it's clear if a message is waiting for you there. Finally, It also cleans up the LeftDrawer a bit as there was a bunch of unused code in the setup.

<img width="499" alt="image" src="https://user-images.githubusercontent.com/213740/189563759-eae4e24c-f923-4901-9b04-83cc82a12897.png">
