### PR TITLE
Fix Send Lotus dialog

### DIFF
--- a/src/pages/Send.vue
+++ b/src/pages/Send.vue
@@ -70,6 +70,7 @@ export default defineComponent({
     return {
       address,
       addressControl,
+      amount,
       isValid: computed(() => {
         if (!amount.value) {
           return false


### PR DESCRIPTION
Missing param for the vue template was causing it to be unable to send lotus anymore.

Closes #633