### PR TITLE
Update Send page to actually provide a link to the sent transaction

### DIFF
--- a/src/components/dialogs/TransactionDialog.vue
+++ b/src/components/dialogs/TransactionDialog.vue
@@ -10,16 +10,24 @@
         <q-tab v-for="n in outpoints.length" :key="n" :name="n" :label="n" />
       </q-tabs>
       <q-tab-panels v-model="tab" animated>
-        <q-tab-panel v-for="n in outpoints.length" :key="n" :name="n">
+        <q-tab-panel
+          v-for="(outpoint, idx) in outpoints"
+          :key="outpoint.txId"
+          :name="idx + 1"
+        >
           <q-item-section class="q-py-lg">
             <span class="text-bold"> Transaction ID </span>
-            <q-item-label>{{ outpoints[n - 1].txId }}</q-item-label>
+            <q-item-label>
+              <a :href="`https://explorer.givelotus.org/tx/${outpoint.txId}`">{{
+                outpoint.txId
+              }}</a>
+            </q-item-label>
             <span class="text-bold"> Type </span>
-            <q-item-label>{{ outpoints[n - 1].type }}</q-item-label>
+            <q-item-label>{{ outpoint.type }}</q-item-label>
             <span class="text-bold"> Address </span>
-            {{ extractAddress(outpoints[n - 1].address) }}
+            {{ extractAddress(outpoint.address) }}
             <span class="text-bold"> Amount </span>
-            {{ outpoints[n - 1].satoshis }}
+            {{ outpoint.satoshis }}
           </q-item-section>
         </q-tab-panel>
       </q-tab-panels>
@@ -46,17 +54,22 @@ export default defineComponent({
       type: Object as PropType<Array<Utxo>>,
       default: () => [] as Utxo[],
     },
+    txid: {
+      type: String,
+      required: true,
+    },
   },
   data() {
     return {
-      outpoint: 1,
       tab: 1,
     }
   },
-  methods: {
-    extractAddress(outpointAddress: string) {
-      return toDisplayAddress(outpointAddress)
-    },
+  setup() {
+    return {
+      extractAddress(outpointAddress: string) {
+        return toDisplayAddress(outpointAddress)
+      },
+    }
   },
 })
 </script>

--- a/src/pages/Send.vue
+++ b/src/pages/Send.vue
@@ -93,15 +93,29 @@ export default defineComponent({
             return
           }
           const satoshiAmount = Number(amount.value * 1000000)
-          await relayClient.sendToPubKeyHash({
-            address: address.value,
-            amount: satoshiAmount,
-          })
-          sentTransactionNotify()
+          relayClient
+            .sendToPubKeyHash({
+              address: address.value,
+              amount: satoshiAmount,
+            })
+            .then(txIds => {
+              const txId = txIds ? txIds[0] : undefined
+              if (txId) {
+                sentTransactionNotify(txId)
+
+                return
+              }
+              sentTransactionNotify()
+            })
+            .catch(err => {
+              console.error(err)
+              errorNotify(new Error('Failed to send transaction'))
+              // Unfreeze UTXOs if stealth tx broadcast fails
+              window.history.length > 1 ? router.go(-1) : router.push('/')
+            })
         } catch (err) {
           console.error(err)
           errorNotify(new Error('Failed to send transaction'))
-          // Unfreeze UTXOs if stealth tx broadcast fails
         } finally {
           window.history.length > 1 ? router.go(-1) : router.push('/')
         }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -40,20 +40,23 @@ export function seedCopiedNotify() {
   infoNotify('Your secret name has been saved to your clipboard.')
 }
 
-export function sentTransactionNotify() {
+export function sentTransactionNotify(txId?: string) {
+  const action = {
+    label: 'View',
+    color: 'secondary',
+    handler: () => {
+      if (txId) {
+        window.url.open(`https://explorer.givelotus.org/tx/${txId}`)
+      }
+    },
+  }
+  const actions = txId ? [action] : []
+
   Notify.create({
     message: '<div class="text-center"> Sent transaction </div>',
     html: true,
     color: 'accent',
-    actions: [
-      {
-        label: 'View',
-        color: 'secondary',
-        handler: () => {
-          /* ... */
-        },
-      },
-    ],
+    actions,
   })
 }
 export function desktopNotify(


### PR DESCRIPTION
There was an view action on the notification from the send page which did not do anything. 
Also, the transaction dialogs did not contain links to our explorer. This commit adds both.

Closes  #624