### PR TITLE
Fix crazy behavior on the stamp amount input box

### DIFF
--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -163,10 +163,10 @@ export default defineComponent({
     },
     innerStampAmount: {
       get() {
-        return Number(this.stampAmount / 1000000).toFixed(2)
+        return this.stampAmount
       },
       set(val: string) {
-        this.$emit('update:stampAmount', Number(val) * 1000000)
+        this.$emit('update:stampAmount', Number(val))
       },
     },
   },

--- a/src/components/panels/ContactCard.vue
+++ b/src/components/panels/ContactCard.vue
@@ -60,10 +60,6 @@ export default defineComponent({
       type: String,
       default: () => '',
     },
-    acceptancePrice: {
-      type: Number,
-      default: () => 5000,
-    },
     avatar: {
       type: String,
       default: () => '',

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -321,11 +321,11 @@ export default defineComponent({
         const stampAmountNumber = Math.max(stampLowerLimit, Number(stampAmount))
         this.setStampAmount({
           address: this.address,
-          stampAmount: stampAmountNumber,
+          stampAmount: stampAmountNumber * 1_000_000,
         })
       },
       get() {
-        return Number(this.getStampAmount(this.address))
+        return Number(this.getStampAmount(this.address) / 1_000_000)
       },
     },
   },

--- a/src/stores/chats.ts
+++ b/src/stores/chats.ts
@@ -443,7 +443,7 @@ export const useChatStore = defineStore('chats', {
         console.error('attempting to set stamp amount for non-existant contact')
         return
       }
-      chat.stampAmount = stampAmount
+      chat.stampAmount = Math.trunc(stampAmount)
     },
     setActiveChat(address: string | null) {
       // make sure address is defined, e.g. Forum is undefined

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -68,8 +68,8 @@ export const defaultAvatars = [
 ]
 
 // Chat constants
-export const defaultStampAmount = 500000
-export const stampLowerLimit = 5000
+export const defaultStampAmount = 10
+export const stampLowerLimit = 10
 
 export const defaultContacts = [
   {


### PR DESCRIPTION
This input box was automatically changing the input and losing the input location of where users were typing. This commit should fix that behavior by not reformating the value on every keypress.

Closes #621