### PR TITLE
Fix signup issue when having only one UTXO available

### DIFF
--- a/src/cashweb/wallet/index.ts
+++ b/src/cashweb/wallet/index.ts
@@ -802,9 +802,9 @@ export class Wallet {
     const signingKeys = []
 
     const amountRequired = transaction.outputAmount
-    const sortedUtxos: BuildableUtxo[] = [
-      ...this.storage.getUtxoMap().values(),
-    ].sort((utxoA, utxoB) => utxoB.satoshis - utxoA.satoshis)
+    const sortedUtxos: BuildableUtxo[] = [...this.storage.getUtxoMap().values()]
+      .filter(utxo => !utxo.frozen)
+      .sort((utxoA, utxoB) => utxoB.satoshis - utxoA.satoshis)
 
     const biggerUtxos = sortedUtxos.filter(
       a =>
@@ -815,6 +815,7 @@ export class Wallet {
             standardInputSize) *
             minFeePerByte,
     )
+
     const utxoSetToUse =
       biggerUtxos.length !== 0
         ? [biggerUtxos[biggerUtxos.length - 1]]


### PR DESCRIPTION
The constructTransaction function was not properly ignoring frozen UTXOs leading to the relay signup failing after the user's metadata had been sent to the metadata server. This was due to it trying to use the same UTXO over again for relay signup (which had just been spent). Additionally, when posting metadata any failures were being consumed leading to it improperly reporting errors.
