### PR TITLE
[bug] Fix clearing of UTXOs when resetting key on setup

### DIFF
--- a/src/cashweb/wallet/index.ts
+++ b/src/cashweb/wallet/index.ts
@@ -955,9 +955,6 @@ export class Wallet {
   // This needs to happen when the seed has potentially changed after
   // the UTXOs have been refreshed.
   clearUtxos() {
-    const outpoints = this.storage.getUtxoMap()
-    for (const [outpointId] of outpoints) {
-      this.deleteUtxo(outpointId)
-    }
+    this.storage.clear()
   }
 }

--- a/src/cashweb/wallet/storage/level-storage.ts
+++ b/src/cashweb/wallet/storage/level-storage.ts
@@ -212,6 +212,8 @@ export class LevelUtxoStore implements UtxoStore {
    * This will delete everything in the store! Don't call it by accident!
    */
   async clear() {
+    this.cache = new Map<UtxoId, Utxo>()
+    this.deletedUtxos = new Set<UtxoId>()
     await this.db.clear()
     await this.getMetadataDatabase().clear()
   }


### PR DESCRIPTION
The deleted UTXO cache was being updated when the wallet was reset this was causing UTXOs not to be re-added when they were scanned again later. So, even though the balances were updated in the Pinia wallet store, the UTXOs would not be available for use when trying to send another transaction.