### PR TITLE
[contacts] Remove default contact that was dead

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -73,10 +73,6 @@ export const stampLowerLimit = 1 // XPI
 
 export const defaultContacts = [
   {
-    name: 'Give Lotus Chat',
-    address: 'lotus_16PSJJK5XfnDCV3sdi3BsgDTa1dS4xezFuH6duwbo',
-  },
-  {
     name: 'Shammah',
     address: 'lotus_16PSJPAVocAM5behRWxqwQnpEVRPJrV4XxbthBhJR',
   },


### PR DESCRIPTION
I removed this bot along time ago, remove the default contact so that people don't send messages into the void for now.
