### PR TITLE
[topics] Update default topics

### DIFF
--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -30,13 +30,19 @@ const defaultTopics = [
     messages: [],
   },
   {
-    topic: 'crypto',
+    topic: 'trading',
     threshold: 0,
     offering: defaultOffering,
     messages: [],
   },
   {
     topic: 'memes',
+    threshold: 0,
+    offering: defaultOffering,
+    messages: [],
+  },
+  {
+    topic: 'help',
     threshold: 0,
     offering: defaultOffering,
     messages: [],


### PR DESCRIPTION
Get rid of the crypto group in favor of a trading group, and add a help topic.
