### PR TITLE
[fix] Capture error on deleting already deleted key

### DIFF
--- a/src/cashweb/wallet/storage/level-storage.ts
+++ b/src/cashweb/wallet/storage/level-storage.ts
@@ -122,9 +122,11 @@ export class LevelUtxoStore implements UtxoStore {
 
   deleteById(id: UtxoId) {
     this.cache.delete(id)
-    // TODO: Handle errors here.
-    this.db.del(id)
     this.deletedUtxos.add(id)
+    // TODO: Handle errors here.
+    this.db
+      .del(id)
+      .catch(err => console.error('Trying to delete already deleted utxo', err))
   }
 
   put(outpoint: Utxo) {


### PR DESCRIPTION
We attempt to clean up state all over the place excessively. This leads sometimes to attempting to delete a UTXO twice and failing to actually clean out the cache. This leads to messages potentially failing to send repeatedly when a UTXO gets "stuck" in this way.
