### PR TITLE
[fix] Remove unused (required) txid prop from TransactionDialog

### DIFF
--- a/src/components/dialogs/TransactionDialog.vue
+++ b/src/components/dialogs/TransactionDialog.vue
@@ -67,10 +67,6 @@ export default defineComponent({
       type: Object as PropType<Array<Utxo>>,
       default: () => [] as Utxo[],
     },
-    txid: {
-      type: String,
-      required: true,
-    },
   },
   data() {
     return {


### PR DESCRIPTION
As per title. Was generating console errors for no good reason.
