### PR TITLE
[ui] Move seed phrase display to settings drawer

### DIFF
--- a/src/components/dialogs/SeedPhraseDialog.vue
+++ b/src/components/dialogs/SeedPhraseDialog.vue
@@ -17,6 +17,13 @@
     <q-card-actions align="right">
       <q-btn
         flat
+        icon="file_copy"
+        size="sm"
+        color="primary"
+        @click="copySeed"
+      />
+      <q-btn
+        flat
         :label="$t('seedPhraseDialog.close')"
         color="primary"
         v-close-popup
@@ -26,14 +33,35 @@
 </template>
 
 <script lang="ts">
+import { copyToClipboard, useQuasar } from 'quasar'
 import { useWalletStore } from 'src/stores/wallet'
 import { defineComponent, computed } from 'vue'
 
 export default defineComponent({
   setup() {
     const walletStore = useWalletStore()
+    const $q = useQuasar()
+    const copySeed = () => {
+      if (!walletStore.seedPhrase) {
+        return
+      }
+      copyToClipboard(walletStore.seedPhrase)
+        .then(() => {
+          $q.notify({
+            message:
+              '<div class="text-center"> Seed copied to clipboard </div>',
+            html: true,
+            color: 'purple',
+          })
+        })
+        .catch(() => {
+          // fail
+        })
+    }
+
     return {
       seedPhrase: computed(() => walletStore.seedPhrase),
+      copySeed,
     }
   },
   props: {

--- a/src/components/panels/SettingsPanel.vue
+++ b/src/components/panels/SettingsPanel.vue
@@ -20,6 +20,11 @@
       />
     </q-dialog>
 
+    <!-- Seed phrase dialog -->
+    <q-dialog v-model="seedPhraseOpen">
+      <seed-phrase-dialog />
+    </q-dialog>
+
     <div class="flex-break" />
     <!-- Drawer -->
     <q-scroll-area class="col">
@@ -103,14 +108,21 @@
 
           <q-item-section>{{ $t('SettingPanel.changeLog') }}</q-item-section>
         </q-item>
+        <q-item clickable v-ripple @click="seedPhraseOpen = true">
+          <q-item-section avatar>
+            <q-icon name="compost" />
+          </q-item-section>
+          <q-item-section>{{ $t('SettingPanel.showSeed') }}</q-item-section>
+        </q-item>
       </q-list>
     </q-scroll-area>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 
+import SeedPhraseDialog from '../dialogs/SeedPhraseDialog.vue'
 import ContactCard from './ContactCard.vue'
 import ContactBookDialog from '../dialogs/ContactBookDialog.vue'
 import { openChat, openPage } from '../../utils/routes'
@@ -123,15 +135,18 @@ export default defineComponent({
     const chats = useChatStore()
     const myProfile = useProfileStore()
     const { profile, inbox } = storeToRefs(myProfile)
+    const seedPhraseOpen = ref(false)
     return {
       deleteMessage: chats.deleteMessage,
       profile,
       inbox,
+      seedPhraseOpen,
     }
   },
   components: {
     ContactCard,
     ContactBookDialog,
+    SeedPhraseDialog,
   },
   data() {
     return {

--- a/src/i18n/en-us/index.ts
+++ b/src/i18n/en-us/index.ts
@@ -107,10 +107,10 @@ export default {
     settings: 'Settings',
     wipeAndSave: 'Remote Wipe Wallet',
     changeLog: 'Changelog',
+    showSeed: 'Show Seed',
   },
   receiveBitcoinDialog: {
     walletStatus: 'Wallet Status',
-    showSeed: 'ShowSeed',
     close: 'Close',
     addressCopied: 'Address copied to clipboard',
   },

--- a/src/i18n/fr-fr/index.ts
+++ b/src/i18n/fr-fr/index.ts
@@ -109,10 +109,10 @@ export default {
     settings: 'Configuration',
     wipeAndSave: 'Consolidation du portefeuille',
     changeLog: 'Changelog',
+    showSeed: 'Montrer la phrase de passe',
   },
   receiveBitcoinDialog: {
     walletStatus: 'Etat du wallet',
-    showSeed: 'Montrer la phrase de passe',
     close: 'Fermer',
     addressCopied: 'Adresse copiée dans le presse papier',
   },

--- a/src/pages/Receive.vue
+++ b/src/pages/Receive.vue
@@ -2,11 +2,6 @@
   <q-page-container>
     <q-page class="q-ma-none q-pa-sm">
       <q-card>
-        <!-- New contact dialog -->
-        <q-dialog v-model="seedPhraseOpen">
-          <seed-phrase-dialog />
-        </q-dialog>
-
         <q-card-section>
           <div class="text-h6">
             {{ $t('receiveBitcoinDialog.walletStatus') }}
@@ -55,9 +50,6 @@
           </div>
         </q-card-section>
         <q-card-actions align="right">
-          <q-btn color="warning" @click="seedPhraseOpen = true">{{
-            $t('receiveBitcoinDialog.showSeed')
-          }}</q-btn>
           <q-btn
             :label="$t('receiveBitcoinDialog.close')"
             color="primary"
@@ -73,7 +65,6 @@
 import { defineComponent, computed } from 'vue'
 
 import QrcodeVue from 'qrcode.vue'
-import SeedPhraseDialog from '../components/dialogs/SeedPhraseDialog.vue'
 import { formatBalance } from '../utils/formatting'
 import { copyToClipboard } from 'quasar'
 import { useWalletStore } from 'src/stores/wallet'
@@ -88,7 +79,6 @@ export default defineComponent({
     }
   },
   components: {
-    SeedPhraseDialog,
     QrcodeVue,
   },
   data() {


### PR DESCRIPTION
Based on user complaints, the seed phrase now shows on the main settings drawer rather than the receive screen. People didn't see the justification for putting it there -- and honestly, it only makes sense to an engineer.
