### PR TITLE
[i18n] Generalize close string

### DIFF
--- a/src/components/dialogs/ImageDialog.vue
+++ b/src/components/dialogs/ImageDialog.vue
@@ -10,7 +10,7 @@
         size="md"
         class="float-right"
         color="primary"
-        :label="$t('imageDialog.close')"
+        :label="$t('close')"
         v-close-popup
       />
     </div>

--- a/src/components/dialogs/SeedPhraseDialog.vue
+++ b/src/components/dialogs/SeedPhraseDialog.vue
@@ -22,12 +22,7 @@
         color="primary"
         @click="copySeed"
       />
-      <q-btn
-        flat
-        :label="$t('seedPhraseDialog.close')"
-        color="primary"
-        v-close-popup
-      />
+      <q-btn flat :label="$t('close')" color="primary" v-close-popup />
     </q-card-actions>
   </q-card>
 </template>

--- a/src/components/dialogs/TransactionDialog.vue
+++ b/src/components/dialogs/TransactionDialog.vue
@@ -42,12 +42,7 @@
     </q-card-section>
 
     <q-card-actions align="right">
-      <q-btn
-        flat
-        :label="$t('transactionDialog.close')"
-        color="primary"
-        v-close-popup
-      />
+      <q-btn flat :label="$t('close')" color="primary" v-close-popup />
     </q-card-actions>
   </q-card>
 </template>

--- a/src/i18n/en-us/index.ts
+++ b/src/i18n/en-us/index.ts
@@ -198,6 +198,6 @@ export default {
     txType: 'Type',
     txAddress: 'Address',
     txAmount: 'Amount',
-    close: 'Fermer',
   },
+  close: 'Close',
 }

--- a/src/i18n/fr-fr/index.ts
+++ b/src/i18n/fr-fr/index.ts
@@ -113,7 +113,6 @@ export default {
   },
   receiveBitcoinDialog: {
     walletStatus: 'Etat du wallet',
-    close: 'Fermer',
     addressCopied: 'Adresse copiée dans le presse papier',
   },
   sendAddressDialog: {
@@ -126,7 +125,6 @@ export default {
   contactBookDialog: {
     contacts: 'Contacts',
     search: 'Recherche...',
-    close: 'Fermer',
   },
   contactItem: {
     address: 'Adresse',
@@ -174,9 +172,7 @@ export default {
     delete: 'Effacer',
     message: 'Etes vous sûr de vouloir effacer ce message ?',
   },
-  imageDialog: {
-    close: 'Fermer',
-  },
+
   profileDialog: {
     cancel: 'Annuler',
     update: 'Mettre à jour',
@@ -197,7 +193,6 @@ export default {
   },
   seedPhraseDialog: {
     seedPhrase: 'Phrase de passe',
-    close: 'Fermer',
   },
   transactionDialog: {
     backingTransactions: 'Transactions',
@@ -205,6 +200,6 @@ export default {
     txType: 'Type',
     txAddress: 'Adresse',
     txAmount: 'Montant',
-    close: 'Fermer',
   },
+  close: 'Fermer',
 }

--- a/src/pages/Receive.vue
+++ b/src/pages/Receive.vue
@@ -50,11 +50,7 @@
           </div>
         </q-card-section>
         <q-card-actions align="right">
-          <q-btn
-            :label="$t('receiveBitcoinDialog.close')"
-            color="primary"
-            @click="close"
-          />
+          <q-btn :label="$t('close')" color="primary" @click="close" />
         </q-card-actions>
       </q-card>
     </q-page>


### PR DESCRIPTION
We don't need the word "Close" specialized for each different dialog box. It's also not setup correctly for english everywhere. This commit should fix that.
