### PR TITLE
[fix] Ensure message send errors don't spam

### DIFF
--- a/src/cashweb/relay/index.ts
+++ b/src/cashweb/relay/index.ts
@@ -588,6 +588,7 @@ export class RelayClient extends ReadOnlyRelayClient {
                 })
                 console.log(`unable to send message after ${errCount} retries`)
                 reject(err)
+                return
               }
               console.log('error sending message', err)
 


### PR DESCRIPTION
Fix a bug where a message send error would enter an infite retry loop causing endless transactions to be spammed incorrectly if the 50tx chain limit was hit... Which is bad.
