### PR TITLE
Ensure chat store is fully restored before loading new messages

### DIFF
--- a/src/boot/setup-apis.ts
+++ b/src/boot/setup-apis.ts
@@ -17,6 +17,7 @@ import { useAppearanceStore } from 'src/stores/appearance'
 import { useForumStore } from 'src/stores/forum'
 import { useTopicStore } from 'src/stores/topics'
 import { useRelayClient, useWallet } from 'src/utils/clients'
+import { useChatStore } from 'src/stores/chats'
 
 function instrumentIndexerClient({
   chronikWs,
@@ -155,6 +156,9 @@ export default boot(async ({ app }) => {
 
   const forumStore = useForumStore()
   await forumStore.restored
+
+  const chatStore = useChatStore()
+  await chatStore.restored
 
   const topicStore = useTopicStore()
   await topicStore.restored


### PR DESCRIPTION
Sometimes loading the local storage takes longer that loading remote storage. When the local storage finally loads, it wipes out the remote messages which were loaded causing issues. This commit temporarily awaits loading all the local storage before remote messages.

In the future it would be better to do both async and ensure the stores are merged.
