### PR TITLE
fix(vscode): fix in-repo vs code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "javascript.format.insertSpaceBeforeFunctionParenthesis": false,
   "javascript.format.insertSpaceAfterConstructor": false,


### PR DESCRIPTION
Formatting settings were out of date with the latest version of VS Code causing it not to correctly format on save.
